### PR TITLE
Fix missing layout room images on registration copy

### DIFF
--- a/php/repositories/SeatregUploadsRepository.php
+++ b/php/repositories/SeatregUploadsRepository.php
@@ -23,4 +23,13 @@ class SeatregUploadsRepository {
         return SEATREG_TEMP_FOLDER_DIR . '/custom_payment_icons/' . $registrationCode;
     }
 
+    /**
+     *
+     * Returns DIR of the directory where custom room images are stored
+     *
+     */
+    public static function getCustomRoomImagesLocationDir($registrationCode) {
+        return SEATREG_TEMP_FOLDER_DIR . '/room_images/' . $registrationCode;
+    }
+
 }

--- a/php/services/SeatregImageCopyService.php
+++ b/php/services/SeatregImageCopyService.php
@@ -1,0 +1,36 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit(); 
+}
+
+class SeatregImageCopyService {
+    public static function copyRegistrationRoomImages($targetRgistrationCode, $destinationRegistrationCode) {
+        $targetCustomRoomImagesLocation = SeatregUploadsRepository::getCustomRoomImagesLocationDir($targetRgistrationCode);
+        $destinationCustomRoomImagesLocation = SeatregUploadsRepository::getCustomRoomImagesLocationDir($destinationRegistrationCode);
+
+        if ( !file_exists($destinationCustomRoomImagesLocation) ) {
+            $dirCreated = mkdir($destinationCustomRoomImagesLocation, 0755, true);
+
+            if ( !$dirCreated ) {
+                return false;
+            }
+        }
+
+        $dir = opendir($targetCustomRoomImagesLocation);
+
+        while (false !== ($file = readdir($dir))) {
+            // Skip the current and parent directory entries
+            if ($file != '.' && $file != '..') {
+                // Copy each file to the destination directory
+                if (!copy($targetCustomRoomImagesLocation . '/' . $file, $destinationCustomRoomImagesLocation . '/' . $file)) {
+                    // If any file fails to copy, return false
+                    return false;
+                }
+            }
+        }
+
+        closedir($dir);
+
+        return true;
+    }
+}

--- a/php/services/SeatregRegistrationService.php
+++ b/php/services/SeatregRegistrationService.php
@@ -134,9 +134,16 @@ class SeatregRegistrationService {
         if( $insertStatus ) {
             $insertStatus = self::insertRegistrationOptions($generatedCode, $registrationData);
             if($insertStatus) {
-                wp_redirect( SEATREG_HOME_PAGE );
+                $insertStatus = SeatregImageCopyService::copyRegistrationRoomImages($registrationCode, $generatedCode);
 
-                die();
+                if($insertStatus) {
+                    wp_redirect( SEATREG_HOME_PAGE );
+
+                    die();
+                }else {
+                    wp_die( esc_html_e('Something went wrong while coping a registration layout images', 'seatreg') );
+                }
+           
             }else {
                 wp_die( esc_html_e('Something went wrong while coping a registration settings', 'seatreg') );
             }
@@ -144,4 +151,5 @@ class SeatregRegistrationService {
             wp_die( esc_html_e('Something went wrong while coping a registration', 'seatreg') );
         }
     }
+
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: reservation, online booking, event management, online registration, seat p
 Requires at least: 5.3
 Requires PHP: 7.2.28
 Tested up to: 6.7.1
-Stable tag: 1.56.2
+Stable tag: 1.56.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -42,6 +42,9 @@ SeatReg is a plugin that offers the following and more to build and manage onlin
 7. Seat custom numbering
 
 == Changelog ==
+
+= 1.56.3 =
+* Fixed an issue where copying a registration did not include the target registration's layout background images.
 
 = 1.56.2 =
 * Added character restrictions to email templates.

--- a/seatreg.php
+++ b/seatreg.php
@@ -6,7 +6,7 @@
 	Author: Siim Kirjanen
 	Author URI: https://github.com/SiimKirjanen
 	Text Domain: seatreg
-	Version: 1.56.2
+	Version: 1.56.3
 	Requires at least: 5.3
 	Requires PHP: 7.2.28
 	License: GPLv2 or later
@@ -53,6 +53,7 @@ require( 'php/services/SeatregActionsService.php' );
 require( 'php/services/SeatregPublicApiService.php' );
 require( 'php/services/SeatregImageUploadService.php' );
 require( 'php/services/SeatregImageDeleteService.php' );
+require( 'php/services/SeatregImageCopyService.php' );
 require( 'php/services/SeatregRandomGenerator.php' );
 require( 'php/services/SeatregTimeService.php' );
 require( 'php/services/SeatregQRCodeService.php' );


### PR DESCRIPTION
Fixed an issue where copying a registration did not include the target registration's layout background images.