### PR TITLE
Fixed registration start and end date

### DIFF
--- a/js/seatreg_admin.js
+++ b/js/seatreg_admin.js
@@ -285,10 +285,22 @@ $('.builder-popup-close').on('click', function() {
 	}
 });
 
+// Helper function to create UTC noon timestamp from dd.mm.yyyy date string
+function createUTCNoonTimestamp(dateText) {
+	// Parse dd.mm.yyyy
+	var parts = dateText.split('.');
+	// Create date at noon UTC (bypasses local timezone)
+	var date = new Date(Date.UTC(parts[2], parts[1] - 1, parts[0], 12, 0, 0));
+	return date.getTime();
+}
+
 $('#registration-start-timestamp').datepicker({
 	altField: '#start-timestamp',
 	altFormat: '@',
-	dateFormat: 'dd.mm.yy'
+	dateFormat: 'dd.mm.yy',
+	onSelect: function(dateText) {
+		$('#start-timestamp').val(createUTCNoonTimestamp(dateText));
+	}
 }).on('keyup', function() {
 	if($(this).val() == '') {
 		$('#start-timestamp').val('');
@@ -300,7 +312,10 @@ $('#registration-start-time').clockTimePicker();
 $('#registration-end-timestamp').datepicker({
 	altField: '#end-timestamp',
 	altFormat: '@',
-	dateFormat: 'dd.mm.yy'
+	dateFormat: 'dd.mm.yy',
+	onSelect: function(dateText) {
+		$('#end-timestamp').val(createUTCNoonTimestamp(dateText));
+	}
 }).on('keyup', function() {
 	if($(this).val() == '') {
 		$('#end-timestamp').val('');

--- a/php/enqueue_admin.php
+++ b/php/enqueue_admin.php
@@ -58,7 +58,7 @@ function seatreg_load_admin_scripts($hook) {
 		wp_enqueue_script('date-format', plugins_url('js/date.format.js', dirname(__FILE__) ), array('jquery'), '1.0.0', true);
 		wp_enqueue_script('seatreg_admin_chart', plugins_url('js/Chart.min.js', dirname(__FILE__) ), array('jquery'), '1.0.0', true);
 		wp_enqueue_script('seatreg-utils', plugins_url('js/utils.js', dirname(__FILE__) ) , array(), '1.0.0', true);
-		wp_enqueue_script('seatreg_admin', plugins_url('js/seatreg_admin.js', dirname(__FILE__) ), array('jquery', 'powertip', 'seatreg_admin_chart', 'seatreg-utils'), '1.23.2', true);
+		wp_enqueue_script('seatreg_admin', plugins_url('js/seatreg_admin.js', dirname(__FILE__) ), array('jquery', 'powertip', 'seatreg_admin_chart', 'seatreg-utils'), '1.23.1', true);
 		wp_enqueue_script('jstz', plugins_url('js/jstz-1.0.4.min.js', dirname(__FILE__) ), array(), '1.0.4', true);
 		wp_enqueue_script('seatreg_builder_script', plugins_url('js/build.js', dirname(__FILE__) ), array('jquery','jquery-ui-core','alertify','vanilla_picker','powertip'), '1.11.1', true);
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: reservation, online booking, event management, online registration, seat p
 Requires at least: 5.3
 Requires PHP: 7.2.28
 Tested up to: 6.9.0
-Stable tag: 1.67.5
+Stable tag: 1.67.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -44,6 +44,9 @@ SeatReg is a plugin that offers the following and more to build and manage onlin
 7. Seat custom numbering
 
 == Changelog ==
+
+= 1.67.6 =
+* Fixed timezone issue where registration start and end dates could display one day earlier than selected in settings.
 
 = 1.67.5 =
 * Fixed WordPress user booking seat limit on email confirmation.


### PR DESCRIPTION
Fixed timezone issue where registration start and end dates could display one day earlier than selected in settings