### PR TITLE
Fixed Powered by footer overlap

### DIFF
--- a/php/enqueue_public.php
+++ b/php/enqueue_public.php
@@ -73,7 +73,7 @@ function seatreg_public_scripts_and_styles() {
 		wp_enqueue_script('jquery-powertip', SEATREG_PLUGIN_FOLDER_URL . 'js/jquery.powertip.js' , array(), '1.2.0', true);
 		wp_enqueue_script('pg-calendar', SEATREG_PLUGIN_FOLDER_URL . 'js/pg-calendar/dist/js/pignose.calendar.full.min.js' , array('jquery'), '1.4.31', false);
 		wp_enqueue_script('seatreg-utils', SEATREG_PLUGIN_FOLDER_URL . 'js/utils.js' , array(), '1.2.0', true);
-		wp_enqueue_script('seatreg-registration', SEATREG_PLUGIN_FOLDER_URL . 'registration/js/registration.js' , array('jquery', 'date-format', 'iscroll-zoom', 'jquery-powertip', 'seatreg-utils'), '1.33.1', true);
+		wp_enqueue_script('seatreg-registration', SEATREG_PLUGIN_FOLDER_URL . 'registration/js/registration.js' , array('jquery', 'date-format', 'iscroll-zoom', 'jquery-powertip', 'seatreg-utils'), '1.33.2', true);
 		wp_enqueue_script('alertify', SEATREG_PLUGIN_FOLDER_URL . 'js/alertify.js', array('jquery'), '1.0.0', true);
 
 		$data = seatreg_get_options_reg($_GET['c']);
@@ -117,6 +117,7 @@ function seatreg_public_scripts_and_styles() {
 			$inlineScript .= 'var activeCalendarDate = "'. esc_js($filterCalendarDate) . '";';
 			$inlineScript .= 'var siteLanguage = "'. esc_js($siteLanguage) . '";';
 			$inlineScript .= 'var controlledScroll = "'. esc_js($data->controlled_scroll) . '";';
+			$inlineScript .= 'var zoomControlsOnTop = "'. esc_js($data->zoom_on_top === '1' ? '1' : '0') . '";';
 			$inlineScript .= 'var customFooterText = "'. esc_js($data->custom_footer_text) . '";';
 			$inlineScript .= 'var registrationTimeRestrictions = jQuery.parseJSON(' . wp_json_encode($registrationTimeRestrictions) . ');';
 			$inlineScript .= 'var bookingRedirectToStatusPage = "'. esc_js($data->booking_redirect_status_page) . '";';

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: reservation, online booking, event management, online registration, seat p
 Requires at least: 5.3
 Requires PHP: 7.2.28
 Tested up to: 6.9.0
-Stable tag: 1.67.10
+Stable tag: 1.67.11
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -44,6 +44,9 @@ SeatReg is a plugin that offers the following and more to build and manage onlin
 7. Seat custom numbering
 
 == Changelog ==
+
+= 1.67.11 =
+* Fixed an issue where the "Powered by" footer could overlap the seat map when the "Zoom controls on top" option was enabled and the map was tall.
 
 = 1.67.10 =
 * Companion now supports searching for bookings by seat number.

--- a/registration/js/registration.js
+++ b/registration/js/registration.js
@@ -122,6 +122,7 @@
 		this.onePersonCheckout = window.onePersonCheckout === '1';
 		this.automaticBookingConfirmDialog = window.automaticBookingConfirmDialog === '1';
 		this.couponsEnabled = window.seatregCouponsEnabled === '1';
+		this.zoomControlsOnTop = window.zoomControlsOnTop === '1';
 		this.appliedCoupon = null;
 	}
 
@@ -1271,6 +1272,7 @@ function setMiddleSecSize(roomSizeWidth, roomSizeHeight) {
 	var infoHeight = $('.top-info-bar').outerHeight(true) || 0;
 	var poweredByHeight = $('#powered-by').outerHeight(true);
 	var cartWidth = $('#controls-wrapper').outerWidth(true);
+	var topZoomHeight = seatReg.zoomControlsOnTop ? $('#zoom-controller').outerHeight(true) : 0;
 	var legendWidth = 0;
 	var spaceForMiddleWidth = screenWidth - 20; //how much room for seat map
 	var spaceForMiddleHeight = screenHeight - 30 - 70 - navHeight - $('#bottom-wrapper').outerHeight(true) - $('#zoom-controller').outerHeight(true);  // - header height, -legend height, navbar height, -spacing  --default mobile
@@ -1293,7 +1295,7 @@ function setMiddleSecSize(roomSizeWidth, roomSizeHeight) {
 		console.log('navHeight height: ', navHeight);
 		console.log('infoHeight height: ', infoHeight); */
 
-		spaceForMiddleHeight = screenHeight - 30 - navHeight - infoHeight - 30 - poweredByHeight;  //- header height, - navbar height, -footer if needed
+		spaceForMiddleHeight = screenHeight - 30 - navHeight - infoHeight - 30 - poweredByHeight - topZoomHeight;  //- header height, - navbar height, -footer if needed, - zoom controls if on top
 
 		if(seatReg.rooms[seatReg.currentRoom].room.legends.length > 0) {
 			$('#legend-wrapper').css('display','inline-block');

--- a/seatreg.php
+++ b/seatreg.php
@@ -6,7 +6,7 @@
 	Author: Siim Kirjanen
 	Author URI: https://github.com/SiimKirjanen
 	Text Domain: seatreg
-	Version: 1.67.10
+	Version: 1.67.11
 	Requires at least: 5.3
 	Requires PHP: 7.2.28
 	License: GPLv2 or later


### PR DESCRIPTION
Fixed an issue where the "Powered by" footer could overlap the seat map when the "Zoom controls on top" option was enabled and the map was tall