### PR TITLE
370 theme conflict

### DIFF
--- a/php/seatreg_filters.php
+++ b/php/seatreg_filters.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_filter( 'show_admin_bar', 'seatreg_hide_admin_bar_from_registration_view' );
 function seatreg_hide_admin_bar_from_registration_view(){
 	if( is_user_logged_in() ) {
-		if( seatreg_is_registration_view_page() || seatreg_is_companion_app_page() ) {
+		if( seatreg_is_registration_view_page() || seatreg_is_companion_app_page() || seatreg_is_booking_confirm_page() || seatreg_is_booking_check_page() ) {
 			return false;
 		}
 		return true;
@@ -43,7 +43,7 @@ function custom_http_status_code() {
     }
 }
 
-add_filter('init', 'seatreg_custom_pages');
+add_action('template_redirect', 'seatreg_custom_pages');
 function seatreg_custom_pages() {
 
 	if( isset($_GET['seatreg']) && $_GET['seatreg'] === 'pdf' ) {

--- a/php/seatreg_filters.php
+++ b/php/seatreg_filters.php
@@ -4,8 +4,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; 
 }
 
-add_filter( 'show_admin_bar', 'seatreg_hide_admin_bar_from_registration_view' );
-function seatreg_hide_admin_bar_from_registration_view(){
+add_filter( 'show_admin_bar', 'seatreg_hide_admin_bar' );
+function seatreg_hide_admin_bar(){
 	if( is_user_logged_in() ) {
 		if( seatreg_is_registration_view_page() || seatreg_is_companion_app_page() || seatreg_is_booking_confirm_page() || seatreg_is_booking_check_page() ) {
 			return false;

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Donate link: https://www.paypal.com/donate?hosted_button_id=9QSGHYKHL6NMU&source
 Tags: reservation, online booking, event management, online registration, seat plan
 Requires at least: 5.3
 Requires PHP: 7.2.28
-Tested up to: 6.9.0
-Stable tag: 1.68.0
+Tested up to: 7.0
+Stable tag: 1.68.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -48,6 +48,9 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 7. Seat custom numbering
 
 == Changelog ==
+
+= 1.68.1 =
+* Fixed an issue where the booking confirmation and booking status pages could show a fatal error with some themes.
 
 = 1.68.0 =
 * Added a "Current booking flow" summary at the top of the registration settings to help you understand how your selected settings shape the way visitors book.

--- a/seatreg.php
+++ b/seatreg.php
@@ -6,7 +6,7 @@
 	Author: Siim Kirjanen
 	Author URI: https://github.com/SiimKirjanen
 	Text Domain: seatreg
-	Version: 1.68.0
+	Version: 1.68.1
 	Requires at least: 5.3
 	Requires PHP: 7.2.28
 	License: GPLv2 or later


### PR DESCRIPTION
- Fix fatal error on booking confirmation pages with some themes
- Hide admin toolbar on booking confirm/status pages
- Rename seatreg_hide_admin_bar_from_registration_view to seatreg_hide_admin_bar
- Bump version and Tested up to 7.0