### PR TITLE
372 pending booking expiration and payment status check

### DIFF
--- a/php/constants.php
+++ b/php/constants.php
@@ -8,7 +8,7 @@ define('SEATREG_SETTINGS_PAGE', admin_url('/admin.php?page=seatreg-options'));
 define('SEATREG_PAGE_ID', 'seatreg');
 
 // DB
-define('SEATREG_DB_VERSION', '1.50');
+define('SEATREG_DB_VERSION', '1.51');
 
 // Validation
 define('SEATREG_MANAGER_ALLOWED_ORDER', array('id', 'date', 'name', 'room', 'nr', 'payment-status'));

--- a/php/constants.php
+++ b/php/constants.php
@@ -8,7 +8,7 @@ define('SEATREG_SETTINGS_PAGE', admin_url('/admin.php?page=seatreg-options'));
 define('SEATREG_PAGE_ID', 'seatreg');
 
 // DB
-define('SEATREG_DB_VERSION', '1.49');
+define('SEATREG_DB_VERSION', '1.50');
 
 // Validation
 define('SEATREG_MANAGER_ALLOWED_ORDER', array('id', 'date', 'name', 'room', 'nr', 'payment-status'));

--- a/php/enqueue_public.php
+++ b/php/enqueue_public.php
@@ -169,7 +169,7 @@ function seatreg_public_scripts_and_styles() {
 			'updatingPageContent' => __('Refreshing page. Please wait.', 'seatreg')
 		));
 
-		if( $bookingData->booking_status_page_custom_styles ) {
+		if( $bookingData && $bookingData->booking_status_page_custom_styles ) {
 			add_action('wp_head', function() use ($bookingData) {
 				seatreg_add_custom_styles($bookingData->booking_status_page_custom_styles);
 			}, 100);

--- a/php/pages/booking_status.php
+++ b/php/pages/booking_status.php
@@ -15,7 +15,7 @@
 	$registrationId = sanitize_text_field($_GET['registration']);
 	$bookings = SeatregBookingRepository::getBookingsById($bookingId);
 	$bookingData = SeatregBookingRepository::getDataRelatedToBooking($bookingId);
-	$customPayments = $bookingData->custom_payments ? json_decode( $bookingData->custom_payments ) : [];
+	$customPayments = ($bookingData && $bookingData->custom_payments) ? json_decode( $bookingData->custom_payments ) : [];
 	$couponsEnabled = SeatregCouponRepository::areCouponsEnabled($registrationId);
 	$appliedCoupon = SeatregCouponRepository::getBookingAppliedCoupon($bookingId);
 ?>

--- a/php/repositories/SeatregActivityLogRepository.php
+++ b/php/repositories/SeatregActivityLogRepository.php
@@ -38,7 +38,7 @@ class SeatregActivityLogRepository {
 
         return $wpdb->get_results( $wpdb->prepare(
             "SELECT * FROM $seatreg_db_table_names->table_seatreg_activity_log
-            WHERE log_type IN ('map', 'settings')
+            WHERE log_type IN ('map', 'settings', 'booking_expiration')
             AND relation_id = %s
             ORDER BY log_date DESC",
             $registrationId

--- a/php/repositories/SeatregBookingRepository.php
+++ b/php/repositories/SeatregBookingRepository.php
@@ -208,18 +208,28 @@ class SeatregBookingRepository {
      * @return (array|object|null)
      *
      */
-    public static function getPendingBookingsThatAreExpired($registrationCode, $expirationTimeInMinutes) {
+    public static function getPendingBookingsThatAreExpired($registrationCode, $expirationTimeInMinutes, $deletablePaymentStatuses = array()) {
         global $wpdb;
         global $seatreg_db_table_names;
+
+        // Delete bookings that have no payment rows falling outside the allowed-to-delete set.
+        // With an empty set this keeps the original behavior: any payment row protects the booking.
+        if( count($deletablePaymentStatuses) > 0 ) {
+            $placeholders = implode(', ', array_fill(0, count($deletablePaymentStatuses), '%s'));
+            $paymentCondition = "AND (SELECT COUNT(*) FROM $seatreg_db_table_names->table_seatreg_payments AS b WHERE b.booking_id = a.booking_id AND b.payment_status NOT IN ($placeholders)) = 0";
+            $queryArgs = array_merge( array($registrationCode, $expirationTimeInMinutes), $deletablePaymentStatuses );
+        }else {
+            $paymentCondition = "AND (SELECT COUNT(*) FROM $seatreg_db_table_names->table_seatreg_payments AS b WHERE b.booking_id = a.booking_id) = 0";
+            $queryArgs = array($registrationCode, $expirationTimeInMinutes);
+        }
 
         return $wpdb->get_results( $wpdb->prepare(
             "SELECT * FROM $seatreg_db_table_names->table_seatreg_bookings AS a
             WHERE a.registration_code = %s
             AND a.status = 1
             AND ((UNIX_TIMESTAMP() - a.booking_date) / 60) > %d
-            AND (SELECT COUNT(*) FROM $seatreg_db_table_names->table_seatreg_payments AS b WHERE b.booking_id = a.booking_id) = 0",
-            $registrationCode,
-            $expirationTimeInMinutes
+            $paymentCondition",
+            $queryArgs
         ) );
     }
 

--- a/php/seatreg_functions.php
+++ b/php/seatreg_functions.php
@@ -2052,9 +2052,13 @@ function seatreg_echo_booking($registrationCode, $bookingId) {
 				$bookingWillBeDeletedTimestamp = $bookingDateTimestampInMinutes + (int)$options->pending_expiration;
 				$bookingTimeToLive = floor($bookingWillBeDeletedTimestamp - (time() / 60));
 
-				if($bookingTimeToLive > 0 && !$hasBlockingPayment) {
-					/* translators: %s is replaced with the pending booking time to live in minutes */
-					echo '<h3 style="color:red">', sprintf(esc_html__('This pending booking will be deleted in about %s minutes if not approved', 'seatreg'), esc_html($bookingTimeToLive)), '</h3>';
+				if(!$hasBlockingPayment) {
+					if($bookingTimeToLive > 0) {
+						/* translators: %s is replaced with the pending booking time to live in minutes */
+						echo '<h3 style="color:red">', sprintf(esc_html__('This pending booking will be deleted in about %s minutes if not approved', 'seatreg'), esc_html($bookingTimeToLive)), '</h3>';
+					}else {
+						echo '<h3 style="color:red">', esc_html__('This pending booking has expired and will be deleted', 'seatreg'), '</h3>';
+					}
 				}
 			}
 			echo '<div style="margin-bottom: 6px"><strong>', esc_html__('Booking id', 'seatreg'), '</strong>: ' , esc_html($bookingId),'</div>';
@@ -2566,7 +2570,7 @@ function seatreg_set_up_db() {
 
 		$sql6 = "CREATE TABLE $seatreg_db_table_names->table_seatreg_activity_log (
 			id int(11) NOT NULL AUTO_INCREMENT,
-			log_type enum('booking', 'map', 'settings') NOT NULL,
+			log_type enum('booking', 'map', 'settings', 'booking_expiration') NOT NULL,
 			relation_id varchar(40) NOT NULL,
 			log_date TIMESTAMP DEFAULT NOW(),
 			log_message text,

--- a/php/seatreg_functions.php
+++ b/php/seatreg_functions.php
@@ -896,9 +896,21 @@ function seatreg_generate_settings_form() {
 			<div class="form-group">
 				<label for="pending-expiration"><?php esc_html_e('Pending booking expiration', 'seatreg'); ?></label>
 				<p class="help-block">
-					<?php esc_html_e('You can enable pending booking expiration after a certain period of time (in minutes). If the booking has some payment related activity, then booking will not be removed. Leave empty for no expiration time.', 'seatreg'); ?>
+					<?php esc_html_e('You can enable pending booking expiration after a certain period of time (in minutes). If the booking has some payment related activity, then booking will not be removed unless you allow specific payment statuses below. Leave empty for no expiration time.', 'seatreg'); ?>
 				</p>
 				<input type="number" class="form-control" id="pending-expiration" name="pending-expiration" autocomplete="off" placeholder="<?php echo esc_html('Expiration time not set', 'seatreg'); ?>" value="<?php echo ($options[0]->pending_expiration) ? esc_html($options[0]->pending_expiration) : ''; ?>" />
+				<div style="padding-left: 20px;">
+					<p class="help-block" style="margin-top: 10px;">
+						<?php esc_html_e('Also delete expired pending bookings that have one of these payment statuses:', 'seatreg'); ?>
+					</p>
+					<?php $previouslySelectedDeletablePaymentStatuses = $options[0]->pending_expiration_payment_statuses ? explode(',', $options[0]->pending_expiration_payment_statuses) : []; ?>
+					<div class="checkbox">
+						<label>
+							<input type="checkbox" name="pending-expiration-payment-statuses[]" value="<?php echo esc_attr(SEATREG_PAYMENT_PROCESSING); ?>" <?php echo in_array(SEATREG_PAYMENT_PROCESSING, $previouslySelectedDeletablePaymentStatuses) ? 'checked' : '' ?> />
+							<?php esc_html_e('Processing', 'seatreg'); ?>
+						</label>
+					</div>
+				</div>
 			</div>
 
 			<div class="form-group">
@@ -2034,12 +2046,13 @@ function seatreg_echo_booking($registrationCode, $bookingId) {
 			echo '<h2>', esc_html( wp_unslash($registration->registration_name) ), '</h2>';
 			
 			if($options && $options->pending_expiration && $bookingStatus === '1') {
-				$hasPaymentEntry = SeatregBookingService::checkIfBookingHasPaymentEntry($bookings[0]->booking_id);
+				$deletablePaymentStatuses = $options->pending_expiration_payment_statuses ? array_filter(explode(',', $options->pending_expiration_payment_statuses)) : array();
+				$hasBlockingPayment = SeatregBookingService::checkIfBookingHasNonExpirablePayment($bookings[0]->booking_id, $deletablePaymentStatuses);
 				$bookingDateTimestampInMinutes = ceil($bookings[0]->booking_date / 60);
 				$bookingWillBeDeletedTimestamp = $bookingDateTimestampInMinutes + (int)$options->pending_expiration;
 				$bookingTimeToLive = floor($bookingWillBeDeletedTimestamp - (time() / 60));
 
-				if($bookingTimeToLive > 0 && !$hasPaymentEntry) {
+				if($bookingTimeToLive > 0 && !$hasBlockingPayment) {
 					/* translators: %s is replaced with the pending booking time to live in minutes */
 					echo '<h3 style="color:red">', sprintf(esc_html__('This pending booking will be deleted in about %s minutes if not approved', 'seatreg'), esc_html($bookingTimeToLive)), '</h3>';
 				}
@@ -2450,6 +2463,7 @@ function seatreg_set_up_db() {
 			paypal_sandbox_mode tinyint(1) NOT NULL DEFAULT 0,
 			payment_completed_set_booking_confirmed tinyint(1) NOT NULL DEFAULT 0,
 			pending_expiration int(11) DEFAULT NULL,
+			pending_expiration_payment_statuses varchar(255) DEFAULT NULL,
 			verification_email_subject varchar(255) DEFAULT NULL,
 			email_verification_template text,
 			pending_booking_email_subject varchar(255) DEFAULT NULL,
@@ -3335,6 +3349,12 @@ function seatreg_update() {
 		$_POST['pending-expiration'] = null;
 	}
 
+	if(!empty($_POST['pending-expiration-payment-statuses']) && is_array($_POST['pending-expiration-payment-statuses'])) {
+		$selectedDeletablePaymentStatuses = implode(',', array_map('sanitize_text_field', $_POST['pending-expiration-payment-statuses']));
+	}else {
+		$selectedDeletablePaymentStatuses = null;
+	}
+
 	if(empty($_POST['bookings-email-limit'])) {
 		$_POST['bookings-email-limit'] = null;
 	}
@@ -3476,6 +3496,7 @@ function seatreg_update() {
 				'send_approved_booking_email' => $_POST['approved-booking-email'],
 				'send_approved_booking_email_qr_code' => ( !isset($_POST['approved-booking-email-qr-code']) || $_POST['approved-booking-email-qr-code'] === '') ? null : sanitize_text_field($_POST['approved-booking-email-qr-code']),
 				'pending_expiration' => $_POST['pending-expiration'],
+				'pending_expiration_payment_statuses' => $selectedDeletablePaymentStatuses,
 				'verification_email_subject' => $_POST['verification-email-subject'] === '' ? null : $_POST['verification-email-subject'],
 				'email_verification_template' => $_POST['email-verification-template'] === '' ? null : SeatregSanitizationService::sanitizeEmailTemplate($_POST['email-verification-template']),
 				'pending_booking_email_subject' => $_POST['pending-booking-email-subject'] === '' ? null : $_POST['pending-booking-email-subject'],

--- a/php/services/SeatregBookingService.php
+++ b/php/services/SeatregBookingService.php
@@ -213,20 +213,33 @@ class SeatregBookingService {
 
     /**
      *
-     * Check if booking has entry in payments table
+     * Check if booking has a payment that prevents it from being deleted by pending booking expiration.
+     * A payment is "blocking" when its status is not in the deletable set. With an empty deletable set
+     * any payment row is blocking
      * @param string $bookingId booking id
+     * @param array $deletablePaymentStatuses payment statuses that are allowed to be deleted
      * @return bool
-     * 
+     *
     */
-    public static function checkIfBookingHasPaymentEntry($bookingId) {
+    public static function checkIfBookingHasNonExpirablePayment($bookingId, $deletablePaymentStatuses = array()) {
         global $wpdb;
         global $seatreg_db_table_names;
 
-        $result = $wpdb->get_var( $wpdb->prepare(
-            "SELECT COUNT(*) FROM $seatreg_db_table_names->table_seatreg_payments
-            WHERE booking_id = %s",
-            $bookingId
-        ));
+        if( count($deletablePaymentStatuses) > 0 ) {
+            $placeholders = implode(', ', array_fill(0, count($deletablePaymentStatuses), '%s'));
+            $result = $wpdb->get_var( $wpdb->prepare(
+                "SELECT COUNT(*) FROM $seatreg_db_table_names->table_seatreg_payments
+                WHERE booking_id = %s
+                AND payment_status NOT IN ($placeholders)",
+                array_merge( array($bookingId), $deletablePaymentStatuses )
+            ));
+        }else {
+            $result = $wpdb->get_var( $wpdb->prepare(
+                "SELECT COUNT(*) FROM $seatreg_db_table_names->table_seatreg_payments
+                WHERE booking_id = %s",
+                $bookingId
+            ));
+        }
 
         if($result) {
             return true;

--- a/php/services/SeatregJobService.php
+++ b/php/services/SeatregJobService.php
@@ -10,9 +10,9 @@ class SeatregJobService {
      * Job that cleans pending bookings if turned on by registration
      *
     */
-    public static function pendingBookingExpirationTimeJob() {    
+    public static function pendingBookingExpirationTimeJob() {
         $registrations = SeatregRegistrationRepository::getRegistrationsWherePendingBookingExpirationIsSet();
-        
+
         if($registrations) {
             foreach($registrations as $registration) {
                 $pendingBookingExpirationTime = (int)$registration->pending_expiration;
@@ -20,11 +20,44 @@ class SeatregJobService {
                 $bookingsToBeDeleted = SeatregBookingRepository::getPendingBookingsThatAreExpired($registration->registration_code, $pendingBookingExpirationTime, $deletablePaymentStatuses);
 
                 if($bookingsToBeDeleted) {
+                    $layout = json_decode($registration->registration_layout);
+                    $roomData = $layout ? $layout->roomData : array();
+                    $bookingsGroupedById = array();
+
                     foreach($bookingsToBeDeleted as $bookingToBeDeleted) {
-                        SeatregBookingService::deleteBooking($bookingToBeDeleted->booking_id);
+                        $bookingsGroupedById[$bookingToBeDeleted->booking_id][] = $bookingToBeDeleted;
+                    }
+
+                    foreach($bookingsGroupedById as $bookingId => $bookingSeats) {
+                        $message = self::buildExpiredBookingLogMessage($bookingSeats, $roomData);
+
+                        seatreg_add_activity_log('booking_expiration', $registration->registration_code, $message, false);
+                        SeatregBookingService::deleteBooking($bookingId);
                     }
                 }
             }
         }
+    }
+
+    /**
+     *
+     * Build the activity log message for a pending booking that expired and is being deleted.
+     *
+     * @param array $bookingSeats Seat rows that share the same booking_id
+     * @param array $roomData Registration layout roomData used to resolve room names
+     * @return string
+     *
+    */
+    private static function buildExpiredBookingLogMessage($bookingSeats, $roomData) {
+        $firstSeat = $bookingSeats[0];
+        $seatDescriptions = array();
+
+        foreach($bookingSeats as $seat) {
+            $roomName = SeatregRegistrationService::getRoomNameFromLayout($roomData, $seat->room_uuid);
+            $seatDescriptions[] = ($roomName ? $roomName : 'Unknown room') . ' - ' . $seat->seat_nr;
+        }
+
+        return "Pending booking expired and was automatically deleted by the pending booking expiration job. Booker email: $firstSeat->booker_email. "
+            . "Seats: " . implode(', ', $seatDescriptions) . ". Booking id: $firstSeat->booking_id";
     }
 }

--- a/php/services/SeatregJobService.php
+++ b/php/services/SeatregJobService.php
@@ -16,7 +16,8 @@ class SeatregJobService {
         if($registrations) {
             foreach($registrations as $registration) {
                 $pendingBookingExpirationTime = (int)$registration->pending_expiration;
-                $bookingsToBeDeleted = SeatregBookingRepository::getPendingBookingsThatAreExpired($registration->registration_code, $pendingBookingExpirationTime);
+                $deletablePaymentStatuses = $registration->pending_expiration_payment_statuses ? array_filter(explode(',', $registration->pending_expiration_payment_statuses)) : array();
+                $bookingsToBeDeleted = SeatregBookingRepository::getPendingBookingsThatAreExpired($registration->registration_code, $pendingBookingExpirationTime, $deletablePaymentStatuses);
 
                 if($bookingsToBeDeleted) {
                     foreach($bookingsToBeDeleted as $bookingToBeDeleted) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: reservation, online booking, event management, online registration, seat p
 Requires at least: 5.3
 Requires PHP: 7.2.28
 Tested up to: 7.0
-Stable tag: 1.68.1
+Stable tag: 1.69.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -48,6 +48,10 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 7. Seat custom numbering
 
 == Changelog ==
+
+= 1.69.0 =
+* Pending booking expiration can now also delete expired bookings whose payment is in the "Processing" state.
+* Auto-deleted expired pending bookings are now recorded in the registration activity log.
 
 = 1.68.1 =
 * Fixed an issue where the booking confirmation and booking status pages could show a fatal error with some themes.

--- a/seatreg.php
+++ b/seatreg.php
@@ -6,7 +6,7 @@
 	Author: Siim Kirjanen
 	Author URI: https://github.com/SiimKirjanen
 	Text Domain: seatreg
-	Version: 1.68.1
+	Version: 1.69.0
 	Requires at least: 5.3
 	Requires PHP: 7.2.28
 	License: GPLv2 or later


### PR DESCRIPTION
Adds a per-registration option to delete expired pending bookings whose payment is in a chosen status (starting with Processing), logs each auto-deletion, and improves the status-page warning.

New setting – "Processing" checkbox under Pending booking expiration; stored in a new pending_expiration_payment_statuses column.
Deletion logic – deletes a booking only if all its payments are in the allowed set (empty set = original behavior).
Activity logging – new booking_expiration log_type; each auto-deleted booking is logged (booker email + seats) to the registration Logs modal.
Status-page warning – uses the same payment rule and stays visible after the countdown hits zero.
Bug fix – guarded null $bookingData on the booking status page and in enqueue.