### PR TITLE
Add custom logo support to booking status page PDF

### DIFF
--- a/js/seatreg_admin.js
+++ b/js/seatreg_admin.js
@@ -2015,6 +2015,42 @@ $('#seatreg-settings-form #custom-payments').on('change', '[data-action="custom-
 	promise.fail = seatreg_admin_ajax_error;
 });
 
+var seatregBookingPdfLogoFrame = null;
+
+$('#seatreg-settings-form').on('click', '[data-action="booking-pdf-logo-select"]', function(e) {
+	e.preventDefault();
+	var $group = $(this).closest('.form-group');
+
+	if(seatregBookingPdfLogoFrame) {
+		seatregBookingPdfLogoFrame.off('select');
+	}
+
+	seatregBookingPdfLogoFrame = wp.media({
+		multiple: false,
+		library: { type: 'image' }
+	});
+
+	seatregBookingPdfLogoFrame.on('select', function() {
+		var attachment = seatregBookingPdfLogoFrame.state().get('selection').first().toJSON();
+		var previewUrl = (attachment.sizes && attachment.sizes.medium) ? attachment.sizes.medium.url : attachment.url;
+
+		$group.find('input[name="booking-pdf-logo-id"]').val(attachment.id);
+		$group.find('.booking-pdf-logo__preview').attr('src', previewUrl).css('display', '');
+		$group.find('[data-action="booking-pdf-logo-remove"]').css('display', '');
+	});
+
+	seatregBookingPdfLogoFrame.open();
+});
+
+$('#seatreg-settings-form').on('click', '[data-action="booking-pdf-logo-remove"]', function(e) {
+	e.preventDefault();
+	var $group = $(this).closest('.form-group');
+
+	$group.find('input[name="booking-pdf-logo-id"]').val('');
+	$group.find('.booking-pdf-logo__preview').attr('src', '').css('display', 'none');
+	$(this).css('display', 'none');
+});
+
 
 $('#seatreg-settings-form #public-api-tokens').on('click', '.remove-token', function() {
 	var tokenBox = $(this).closest('.token-box');

--- a/php/bookings/SeatregBookingPDF.php
+++ b/php/bookings/SeatregBookingPDF.php
@@ -11,6 +11,8 @@ class SeatregBookingPDF extends tFPDF {
     private $_usingSeats;
     private $_customFields;
     private $_roomData;
+    private $_logoPath;
+    private $_logoPosition;
 
     public function __construct($bookingId, $bookings, $bookingData) {
         parent::__construct();
@@ -22,6 +24,15 @@ class SeatregBookingPDF extends tFPDF {
     }
 
     function Header() {
+        if( $this->_logoPath && in_array($this->_logoPosition, array('top-left', 'top-right'), true) ) {
+            $this->renderLogo();
+        }
+
+        // Push the header text below the logo so they don't overlap when the logo is top-left.
+        if( $this->_logoPath && $this->_logoPosition === 'top-left' ) {
+            $this->SetY( $this->GetY() + $this->getLogoHeight() + 4 );
+        }
+
         $this->SetFont('DejaVu','',14);
         $this->Cell(30, 0, $this->_bookingData->registration_name , 0, 1, 'L');
         $this->Ln(6);
@@ -31,9 +42,17 @@ class SeatregBookingPDF extends tFPDF {
         $this->Ln(10);
     }
 
+    function Footer() {
+        if( $this->_logoPath && in_array($this->_logoPosition, array('bottom-left', 'bottom-right'), true) ) {
+            $this->renderLogo();
+        }
+    }
+
     public function setUp() {
         $this->SetAuthor('SeatReg WordPress');
         $this->AddFont('DejaVu','','DejaVuSans.ttf', true);
+        // Resolve the logo before AddPage() since Header()/Footer() fire during it.
+        $this->setUpLogo();
         $this->AliasNbPages();
         $this->AddPage();
         $this->SetFont('DejaVu','',10);
@@ -48,6 +67,89 @@ class SeatregBookingPDF extends tFPDF {
         
         $this->_payment = SeatregPaymentRepository::getPaymentByBookingId( $this->_bookingId );
         $this->_customFields = ($this->_bookingData->custom_fields !== null) ? json_decode( $this->_bookingData->custom_fields, true ) : [];
+    }
+
+    protected function setUpLogo() {
+        $allowedPositions = array('top-left', 'top-right', 'bottom-left', 'bottom-right');
+
+        if( empty($this->_bookingData->booking_pdf_logo_id) || !in_array($this->_bookingData->booking_pdf_logo_position, $allowedPositions, true) ) {
+            return;
+        }
+
+        $path = get_attached_file( $this->_bookingData->booking_pdf_logo_id );
+
+        if( !$path || !file_exists($path) ) {
+            return;
+        }
+
+        // tFPDF can only render raster images.
+        $extension = strtolower( pathinfo($path, PATHINFO_EXTENSION) );
+        if( !in_array($extension, array('jpg', 'jpeg', 'png', 'gif'), true) ) {
+            return;
+        }
+
+        $this->_logoPath = $path;
+        $this->_logoPosition = $this->_bookingData->booking_pdf_logo_position;
+    }
+
+    // The logo size is defined by the source image itself (pixels converted to mm),
+    // so it can be controlled by picking a different image/resolution in the media library.
+    // Returns [width, height] in mm.
+    protected function getLogoDimensions() {
+        $dpi = 96;
+        $size = @getimagesize( $this->_logoPath );
+
+        if( !$size || empty($size[0]) || empty($size[1]) ) {
+            return array(0, 0);
+        }
+
+        $width = $size[0] / $dpi * 25.4;
+        $height = $size[1] / $dpi * 25.4;
+
+        // Safety clamp: never let the logo exceed the usable page area (keep aspect ratio).
+        $maxWidth = $this->w - $this->lMargin - $this->rMargin;
+        $maxHeight = $this->h - $this->tMargin - $this->bMargin;
+        $ratio = min( 1, $maxWidth / $width, $maxHeight / $height );
+
+        return array( $width * $ratio, $height * $ratio );
+    }
+
+    protected function getLogoHeight() {
+        list( , $height ) = $this->getLogoDimensions();
+
+        return $height;
+    }
+
+    protected function renderLogo() {
+        list( $width, $height ) = $this->getLogoDimensions();
+
+        // A Cell with height 0 positions text by its baseline, so the header title's
+        // glyphs sit ~0.4 * font-size above the top margin. Nudge top logos up by the
+        // same amount so their top edge lines up with the title instead of looking lower.
+        $topAlign = ( 14 / $this->k ) * 0.4;
+
+        switch( $this->_logoPosition ) {
+            case 'top-left':
+                $x = $this->lMargin;
+                $y = $this->tMargin - $topAlign;
+                break;
+            case 'top-right':
+                $x = $this->w - $this->rMargin - $width;
+                $y = $this->tMargin - $topAlign;
+                break;
+            case 'bottom-left':
+                $x = $this->lMargin;
+                $y = $this->h - $this->tMargin - $height;
+                break;
+            case 'bottom-right':
+                $x = $this->w - $this->rMargin - $width;
+                $y = $this->h - $this->tMargin - $height;
+                break;
+            default:
+                return;
+        }
+
+        $this->Image( $this->_logoPath, $x, $y, $width, $height );
     }
 
     public function printPDF() {

--- a/php/constants.php
+++ b/php/constants.php
@@ -8,7 +8,7 @@ define('SEATREG_SETTINGS_PAGE', admin_url('/admin.php?page=seatreg-options'));
 define('SEATREG_PAGE_ID', 'seatreg');
 
 // DB
-define('SEATREG_DB_VERSION', '1.51');
+define('SEATREG_DB_VERSION', '1.52');
 
 // Validation
 define('SEATREG_MANAGER_ALLOWED_ORDER', array('id', 'date', 'name', 'room', 'nr', 'payment-status'));

--- a/php/enqueue_admin.php
+++ b/php/enqueue_admin.php
@@ -26,6 +26,7 @@ function seatreg_load_admin_scripts($hook) {
 	);
 
 	if(in_array($screen->id, $allowedToLoadStylesAndScripts)) {
+		wp_enqueue_media();
 		wp_enqueue_style('jquery-ui-style', plugins_url('css/custom-theme/jquery-ui-1.9.2.custom.min.css', dirname(__FILE__) ), array(), '1.9.2', 'all');
 		wp_enqueue_style('bootstrap-styles', plugins_url('css/bootstrap.min.css', dirname(__FILE__) ), array(), '3.1.1', 'all');
 		wp_enqueue_style('jquery-ui-multidatespicker', plugins_url('js/jquery-ui-multidatespicker/jquery-ui.multidatespicker.css', dirname(__FILE__) ), array(), '1.6.4', 'all');
@@ -58,7 +59,7 @@ function seatreg_load_admin_scripts($hook) {
 		wp_enqueue_script('date-format', plugins_url('js/date.format.js', dirname(__FILE__) ), array('jquery'), '1.0.0', true);
 		wp_enqueue_script('seatreg_admin_chart', plugins_url('js/Chart.min.js', dirname(__FILE__) ), array('jquery'), '1.0.0', true);
 		wp_enqueue_script('seatreg-utils', plugins_url('js/utils.js', dirname(__FILE__) ) , array(), '1.2.0', true);
-		wp_enqueue_script('seatreg_admin', plugins_url('js/seatreg_admin.js', dirname(__FILE__) ), array('jquery', 'powertip', 'seatreg_admin_chart', 'seatreg-utils'), '1.28.0', true);
+		wp_enqueue_script('seatreg_admin', plugins_url('js/seatreg_admin.js', dirname(__FILE__) ), array('jquery', 'powertip', 'seatreg_admin_chart', 'seatreg-utils'), '1.29.0', true);
 		wp_enqueue_script('jstz', plugins_url('js/jstz-1.0.4.min.js', dirname(__FILE__) ), array(), '1.0.4', true);
 		wp_enqueue_script('seatreg_builder_script', plugins_url('js/build.js', dirname(__FILE__) ), array('jquery','jquery-ui-core','alertify','vanilla_picker','powertip', 'seatreg-utils', 'seatreg_admin'), '1.11.1', true);
 

--- a/php/seatreg_functions.php
+++ b/php/seatreg_functions.php
@@ -1017,6 +1017,35 @@ function seatreg_generate_settings_form() {
 			</div>
 
 			<div class="form-group">
+				<label><?php esc_html_e('Booking PDF logo', 'seatreg'); ?></label>
+				<p class="help-block">
+					<?php esc_html_e('Select a logo to show on the booking status page PDF and choose in which corner it should appear.', 'seatreg'); ?>
+				</p>
+				<?php
+					$bookingPdfLogoId = $options[0]->booking_pdf_logo_id;
+					$bookingPdfLogoUrl = $bookingPdfLogoId ? wp_get_attachment_image_url( $bookingPdfLogoId, 'medium' ) : '';
+					$bookingPdfLogoPosition = $options[0]->booking_pdf_logo_position;
+				?>
+				<div class="booking-pdf-logo">
+					<input type="hidden" name="booking-pdf-logo-id" value="<?php echo esc_attr($bookingPdfLogoId); ?>">
+					<img class="booking-pdf-logo__preview" src="<?php echo esc_url($bookingPdfLogoUrl); ?>" alt="" style="max-width:100px; height:auto; margin-bottom:10px; <?php echo $bookingPdfLogoUrl ? '' : 'display:none;'; ?>">
+					<div>
+						<button type="button" class="btn btn-default btn-sm" data-action="booking-pdf-logo-select"><?php esc_html_e('Select logo', 'seatreg'); ?></button>
+						<button type="button" class="btn btn-default btn-sm" data-action="booking-pdf-logo-remove" style="<?php echo $bookingPdfLogoUrl ? '' : 'display:none;'; ?>"><?php esc_html_e('Remove logo', 'seatreg'); ?></button>
+					</div>
+				</div>
+				<div style="padding-left:20px; margin-top:10px;">
+					<label for="booking-pdf-logo-position"><?php esc_html_e('Logo position', 'seatreg'); ?></label>
+				<select class="form-control" id="booking-pdf-logo-position" name="booking-pdf-logo-position">
+					<option value="top-left" <?php echo empty($bookingPdfLogoPosition) || $bookingPdfLogoPosition === 'top-left' ? 'selected' : ''; ?>><?php esc_html_e('Top left', 'seatreg'); ?></option>
+					<option value="top-right" <?php echo $bookingPdfLogoPosition === 'top-right' ? 'selected' : ''; ?>><?php esc_html_e('Top right', 'seatreg'); ?></option>
+					<option value="bottom-left" <?php echo $bookingPdfLogoPosition === 'bottom-left' ? 'selected' : ''; ?>><?php esc_html_e('Bottom left', 'seatreg'); ?></option>
+					<option value="bottom-right" <?php echo $bookingPdfLogoPosition === 'bottom-right' ? 'selected' : ''; ?>><?php esc_html_e('Bottom right', 'seatreg'); ?></option>
+				</select>
+				</div>
+			</div>
+
+			<div class="form-group">
 				<label for="approved-booking-email-qr-code"><?php esc_html_e('Approved booking receipt email QR code', 'seatreg'); ?></label>
 				<p class="help-block">
 					<?php
@@ -2515,6 +2544,8 @@ function seatreg_set_up_db() {
 			automatic_booking_confirm_dialog tinyint(0) NOT NULL DEFAULT 0,
 			enable_coupons tinyint(0) NOT NULL DEFAULT 0,
 			coupons text,
+			booking_pdf_logo_id int(11) DEFAULT NULL,
+			booking_pdf_logo_position varchar(20) DEFAULT NULL,
 			PRIMARY KEY  (id)
 		) $charset_collate;";
 	  
@@ -3567,6 +3598,8 @@ function seatreg_update() {
 				'automatic_booking_confirm_dialog' => $_POST['automatic-booking-confirm-dialog'],
 				'enable_coupons' => $_POST['enable_coupons'],
 				'coupons' => $coupons,
+				'booking_pdf_logo_id' => empty($_POST['booking-pdf-logo-id']) ? null : intval($_POST['booking-pdf-logo-id']),
+				'booking_pdf_logo_position' => in_array($_POST['booking-pdf-logo-position'] ?? '', array('top-left', 'top-right', 'bottom-left', 'bottom-right'), true) ? sanitize_text_field($_POST['booking-pdf-logo-position']) : null,
 			 ),
 			array(
 				'registration_code' => sanitize_text_field($_POST['registration_code'])

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: reservation, online booking, event management, online registration, seat p
 Requires at least: 5.3
 Requires PHP: 7.2.28
 Tested up to: 7.0
-Stable tag: 1.69.1
+Stable tag: 1.70.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -48,6 +48,9 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 7. Seat custom numbering
 
 == Changelog ==
+
+= 1.70.0 =
+* Added the ability to show a custom logo on the booking status page PDF, with a selectable corner position, configurable per registration in the settings.
 
 = 1.69.1 =
 * Added a settings warning when scheduled tasks aren't running, since this can stop pending bookings from expiring automatically.

--- a/seatreg.php
+++ b/seatreg.php
@@ -6,7 +6,7 @@
 	Author: Siim Kirjanen
 	Author URI: https://github.com/SiimKirjanen
 	Text Domain: seatreg
-	Version: 1.69.1
+	Version: 1.70.0
 	Requires at least: 5.3
 	Requires PHP: 7.2.28
 	License: GPLv2 or later


### PR DESCRIPTION
Adds the ability to show a custom logo on the booking status page PDF. The logo is
configured per registration in the settings and can be placed in any of the four page
corners.