### PR TITLE
Add custom "Booking not found" text to the booking status page

### DIFF
--- a/js/seatreg_admin.js
+++ b/js/seatreg_admin.js
@@ -2510,7 +2510,18 @@ function seatregRenderBookingFlowSummary() {
 		}
 		var pendingExpiration = parseInt($form.find('#pending-expiration').val(), 10);
 		if (!isNaN(pendingExpiration) && pendingExpiration > 0) {
-			afterBooking.push(item(seatregFlowFormat(t('flowPendingExpiration'), [pendingExpiration]), '#pending-expiration'));
+			var expirationText = seatregFlowFormat(t('flowPendingExpiration'), [pendingExpiration]);
+
+			// Payment statuses that don't block deletion of an expired pending booking.
+			var deletableStatusLabels = [];
+			$form.find('input[name="pending-expiration-payment-statuses[]"]:checked').each(function() {
+				deletableStatusLabels.push($(this).closest('label').text().trim());
+			});
+			if (deletableStatusLabels.length > 0) {
+				expirationText += ' ' + seatregFlowFormat(t('flowPendingExpirationStatuses'), [deletableStatusLabels.join(', ')]);
+			}
+
+			afterBooking.push(item(expirationText, '#pending-expiration'));
 		}
 
 		// A completed payment can auto-approve a pending booking (per payment method).

--- a/php/constants.php
+++ b/php/constants.php
@@ -8,7 +8,7 @@ define('SEATREG_SETTINGS_PAGE', admin_url('/admin.php?page=seatreg-options'));
 define('SEATREG_PAGE_ID', 'seatreg');
 
 // DB
-define('SEATREG_DB_VERSION', '1.52');
+define('SEATREG_DB_VERSION', '1.53');
 
 // Validation
 define('SEATREG_MANAGER_ALLOWED_ORDER', array('id', 'date', 'name', 'room', 'nr', 'payment-status'));

--- a/php/enqueue_admin.php
+++ b/php/enqueue_admin.php
@@ -59,7 +59,7 @@ function seatreg_load_admin_scripts($hook) {
 		wp_enqueue_script('date-format', plugins_url('js/date.format.js', dirname(__FILE__) ), array('jquery'), '1.0.0', true);
 		wp_enqueue_script('seatreg_admin_chart', plugins_url('js/Chart.min.js', dirname(__FILE__) ), array('jquery'), '1.0.0', true);
 		wp_enqueue_script('seatreg-utils', plugins_url('js/utils.js', dirname(__FILE__) ) , array(), '1.2.0', true);
-		wp_enqueue_script('seatreg_admin', plugins_url('js/seatreg_admin.js', dirname(__FILE__) ), array('jquery', 'powertip', 'seatreg_admin_chart', 'seatreg-utils'), '1.29.0', true);
+		wp_enqueue_script('seatreg_admin', plugins_url('js/seatreg_admin.js', dirname(__FILE__) ), array('jquery', 'powertip', 'seatreg_admin_chart', 'seatreg-utils'), '1.30.0', true);
 		wp_enqueue_script('jstz', plugins_url('js/jstz-1.0.4.min.js', dirname(__FILE__) ), array(), '1.0.4', true);
 		wp_enqueue_script('seatreg_builder_script', plugins_url('js/build.js', dirname(__FILE__) ), array('jquery','jquery-ui-core','alertify','vanilla_picker','powertip', 'seatreg-utils', 'seatreg_admin'), '1.11.1', true);
 

--- a/php/seatreg_functions.php
+++ b/php/seatreg_functions.php
@@ -749,6 +749,25 @@ function seatreg_generate_settings_form() {
 			</div>
 
 			<div class="form-group">
+				<label><?php esc_html_e('Additional text for "Booking not found" status page', 'seatreg'); ?></label>
+				<p class="help-block"><?php esc_html_e('When a booking cannot be found on the booking status page, this text is shown below the "Booking not found" message. Leave empty to show only the default message.', 'seatreg'); ?></p>
+				<?php
+				$bookingNotFoundTextEditorSettings = array(
+				    'wpautop' => true, // enable auto paragraph
+				    'textarea_name' => 'booking-not-found-text',
+				    'textarea_rows' => 4,
+				    'media_buttons' => false,
+				    'teeny' => true, // minimal toolbar
+				    'tinymce' => array(
+				        // minimal toolbar without list buttons
+				        'toolbar1' => 'bold,italic,underline,blockquote,strikethrough,alignleft,aligncenter,alignright,undo,redo,link,unlink,fullscreen',
+				    ),
+				);
+				wp_editor($options[0]->booking_not_found_text, 'bookingNotFoundTextEditor', $bookingNotFoundTextEditorSettings)
+				?>
+			</div>
+
+			<div class="form-group">
 			<label for="one-person-checkout"><?php esc_html_e('One person checkout', 'seatreg'); ?></label>
 				<p class="help-block"><?php esc_html_e("By default, during booking checkout, information must be entered separately for each seat. The 'One Person Checkout' option simplifies this by requiring details for only one seat, and if multiple seats are selected, the same data will be copied to all seats behind the scenes.", 'seatreg'); ?></p>
 				<div class="checkbox">
@@ -2111,6 +2130,9 @@ function seatreg_echo_booking($registrationCode, $bookingId) {
 			}
 		}else {
 			esc_html_e('Booking not found.', 'seatreg');
+			if( $options && $options->booking_not_found_text ) {
+				echo '<div style="margin-top: 12px;">', wp_kses_post($options->booking_not_found_text), '</div>';
+			}
 			die();
 		}
 	}else {
@@ -2546,6 +2568,7 @@ function seatreg_set_up_db() {
 			coupons text,
 			booking_pdf_logo_id int(11) DEFAULT NULL,
 			booking_pdf_logo_position varchar(20) DEFAULT NULL,
+			booking_not_found_text text,
 			PRIMARY KEY  (id)
 		) $charset_collate;";
 	  
@@ -3461,6 +3484,12 @@ function seatreg_update() {
 		$_POST['custom-footer-text'] = null;
 	}
 
+	if( !empty($_POST['booking-not-found-text']) ) {
+	    $_POST['booking-not-found-text'] = wp_kses_post(wpautop($_POST['booking-not-found-text']));
+	}else {
+		$_POST['booking-not-found-text'] = null;
+	}
+
 	if( !isset($_POST['show-pending-booking-pdf']) ) {
 		$_POST['show-pending-booking-pdf'] = 0;
 	}else {
@@ -3600,6 +3629,7 @@ function seatreg_update() {
 				'coupons' => $coupons,
 				'booking_pdf_logo_id' => empty($_POST['booking-pdf-logo-id']) ? null : intval($_POST['booking-pdf-logo-id']),
 				'booking_pdf_logo_position' => in_array($_POST['booking-pdf-logo-position'] ?? '', array('top-left', 'top-right', 'bottom-left', 'bottom-right'), true) ? sanitize_text_field($_POST['booking-pdf-logo-position']) : null,
+				'booking_not_found_text' => $_POST['booking-not-found-text'],
 			 ),
 			array(
 				'registration_code' => sanitize_text_field($_POST['registration_code'])

--- a/php/seatreg_strings.php
+++ b/php/seatreg_strings.php
@@ -288,6 +288,8 @@ function seatreg_generate_admin_strings() {
     $translations->flowBookerPendingNotification = esc_html__('The booker is emailed when their booking becomes pending.', 'seatreg');
     /* translators: %d: number of minutes */
     $translations->flowPendingExpiration = esc_html__('If there is no payment activity, a pending booking is automatically removed after %d minutes.', 'seatreg');
+    /* translators: %s: comma-separated list of payment statuses */
+    $translations->flowPendingExpirationStatuses = esc_html__('Expired pending bookings are also removed even if they have one of these payment statuses: %s.', 'seatreg');
     $translations->flowAutoApproved = esc_html__('Bookings are approved automatically.', 'seatreg');
     $translations->flowPayment = esc_html__('Payment is requested on the booking status page after the booking is made.', 'seatreg');
     $translations->flowCoupons = esc_html__('In the cart, bookers can apply a coupon code to receive a discount.', 'seatreg');

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,7 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 
 = 1.70.0 =
 * Added the ability to show a custom logo on the booking status page PDF, with a selectable corner position, configurable per registration in the settings.
+* Added an optional custom text that is shown below the "Booking not found" message on the booking status page, configurable per registration in the settings.
 
 = 1.69.1 =
 * Added a settings warning when scheduled tasks aren't running, since this can stop pending bookings from expiring automatically.


### PR DESCRIPTION
Adds an optional, per-registration custom text that is shown below the static "Booking not found" message on the booking status page.

Also surfaces the pending-expiration payment statuses in the booking flow summary.