### PR TITLE
Attach booking PDF to approved booking email via new keyword

### DIFF
--- a/php/bookings/SeatregBookingPDF.php
+++ b/php/bookings/SeatregBookingPDF.php
@@ -152,7 +152,31 @@ class SeatregBookingPDF extends tFPDF {
         $this->Image( $this->_logoPath, $x, $y, $width, $height );
     }
 
+    public function getFileName() {
+        return sanitize_file_name( $this->_bookingData->registration_name . '_' . $this->_bookingId ) . '.pdf';
+    }
+
     public function printPDF() {
+        $this->buildDocument();
+
+        $this->Output($this->getFileName(), 'I');
+    }
+
+    /**
+     *
+     * Build the document and return it as a string instead of streaming it to the browser.
+     * Used for email attachments so the PDF never has to be written to disk.
+     *
+     * @return string Raw PDF bytes
+     *
+     */
+    public function getPDFString() {
+        $this->buildDocument();
+
+        return $this->Output('S');
+    }
+
+    protected function buildDocument() {
 
         foreach( $this->_bookings as $booking ) {
             $placeNumberText = $this->_bookingData->using_seats ? esc_html__('Seat number', 'seatreg') : esc_html__('Place number', 'seatreg');
@@ -213,8 +237,6 @@ class SeatregBookingPDF extends tFPDF {
             
             $this->image(SEATREG_TEMP_FOLDER_DIR. '/' . $this->_bookingId . '.png');
         }
-        
-        $this->Output($this->_bookingData->registration_name . '_' .  $this->_bookingId . '.pdf', 'I');	
     }
 
     protected function getStatus($status) {

--- a/php/constants.php
+++ b/php/constants.php
@@ -76,6 +76,7 @@ define('SEATREG_TEMPLATE_PAYMENT_TABLE', '[payment-table]');
 define('SEATREG_TEMPLATE_BOOKING_ID', '[booking-id]');
 define('SEATREG_TEMPLATE_BOOKING_APPROVED_EMAIL_CUSTOM_TEXT', '[custom-approved-email-text]');
 define('SEATREG_TEMPLATE_BOOKING_PDF_LINK', '[booking-pdf-link]');
+define('SEATREG_TEMPLATE_BOOKING_PDF_ATTACHMENT', '[booking-pdf-attachment]');
 
 // Time related
 define('CALENDAR_DATE_FORMAT', 'Y-m-d');

--- a/php/emails.php
+++ b/php/emails.php
@@ -77,6 +77,7 @@ function seatreg_send_approved_booking_email($bookingId, $registrationCode, $tem
     $fromEmail = getEmailFromAddress($registration->email_from_address);
     $message = '';
     $qrType = $registration->send_approved_booking_email_qr_code;
+    $pdfAttached = false;
 
     if($template) {
         $message = SeatregTemplateService::approvedBookingTemplateProcessing($template, $bookingStatusUrl, $bookings, $registrationCustomFields, $bookingId, $registration, $couponsEnabled, $appliedCoupon);
@@ -100,6 +101,24 @@ function seatreg_send_approved_booking_email($bookingId, $registrationCode, $tem
             $message .= SeatregBookingService::generatePaymentTable($bookingId, $couponsEnabled, $appliedCoupon);
         }
     }
+
+    $pdfContent = '';
+    $pdfFileName = '';
+
+    if( $template && SeatregTemplateService::doesTemplateKeywordExist($template, SEATREG_TEMPLATE_BOOKING_PDF_ATTACHMENT) ) {
+        require_once( SEATREG_PLUGIN_FOLDER_DIR . 'php/bookings/SeatregBookingPDF.php' );
+
+        $bookingData = SeatregBookingRepository::getDataRelatedToBooking($bookingId);
+
+        if( $bookingData ) {
+            $pdf = new SeatregBookingPDF($bookingId, $bookings, $bookingData);
+            $pdfContent = $pdf->getPDFString();
+            $pdfFileName = $pdf->getFileName();
+            $pdfAttached = true;
+        }
+    }
+
+    SeatregEmailTemplateService::prepareBookingPdfAttachment($pdfContent, $pdfFileName);
 
     if( extension_loaded('gd') && $qrType ) {
         $qrContent = SeatregRegQRCodeService::getQRCodeContent( $bookingId, $registration->registration_code, $qrType);
@@ -126,8 +145,16 @@ function seatreg_send_approved_booking_email($bookingId, $registrationCode, $tem
         "FROM: $fromEmail"
     ));
 
+    //Release the PDF so later emails in this request don't get it attached.
+    SeatregEmailTemplateService::prepareBookingPdfAttachment();
+
     if($isSent) {
         $activityMessage = $qrType ? "Approved booking email with QR Code sent to $bookerEmail": "Approved booking email sent to $bookerEmail";
+
+        if( $pdfAttached ) {
+            $activityMessage .= ' with booking PDF attached';
+        }
+
         seatreg_add_activity_log('booking', $bookingId, $activityMessage, false);
         return true;
     }

--- a/php/seatreg_functions.php
+++ b/php/seatreg_functions.php
@@ -1090,6 +1090,7 @@ function seatreg_generate_settings_form() {
 					<code>[booking-table]</code> <?php esc_html_e('(optional) will be converted to booking table', 'seatreg'); ?> <br>
 					<code>[payment-table]</code> <?php esc_html_e('(optional) will be converted to payment table', 'seatreg'); ?> <br>
 					<code><?php echo esc_html(SEATREG_TEMPLATE_BOOKING_PDF_LINK); ?></code> <?php esc_html_e('(optional) will be converted to booking PDF link', 'seatreg'); ?> <br>
+					<code><?php echo esc_html(SEATREG_TEMPLATE_BOOKING_PDF_ATTACHMENT); ?></code> <?php esc_html_e('(optional) will attach the booking PDF to the email. The keyword itself is not displayed in the email', 'seatreg'); ?> <br>
 					<code><?php echo esc_html(SEATREG_TEMPLATE_BOOKING_APPROVED_EMAIL_CUSTOM_TEXT); ?></code> <?php esc_html_e('(optional) will be converted to text added to booking in booking-manager. Useful if you want to provide custom text specific to the booking.', 'seatreg'); ?> <br>
 				</p>
 				<textarea rows="6" class="form-control" id="approved-booking-email-template" name="approved-booking-email-template" placeholder="<?php esc_html_e('Using system default message', 'seatreg'); ?>"><?php echo esc_textarea($options[0]->approved_booking_email_template); ?></textarea>

--- a/php/services/SeatregEmailTemplateService.php
+++ b/php/services/SeatregEmailTemplateService.php
@@ -126,4 +126,58 @@ class SeatregEmailTemplateService {
             }
         } );
     }
+
+    /**
+     * Whether the phpmailer_init booking PDF handler has been registered this request.
+     *
+     * @var bool
+     */
+    private static $pdfAttachRegistered = false;
+
+    /**
+     * Queue a generated booking PDF to be attached to the next outgoing email. The PDF is
+     * held in memory only - nothing is written to the uploads folder. Call without arguments
+     * after sending (or when there is no PDF) to clear a previously queued one.
+     *
+     * @param string $pdfContent Raw PDF bytes, or '' to clear.
+     * @param string $fileName   File name the booker sees in the email.
+     */
+    public static function prepareBookingPdfAttachment( $pdfContent = '', $fileName = 'booking.pdf' ) {
+        // Reset first so an email without a PDF never inherits a previous one's attachment.
+        $GLOBALS['seatreg_email_pdf_attachment'] = null;
+
+        if ( ! $pdfContent ) {
+            return;
+        }
+
+        $GLOBALS['seatreg_email_pdf_attachment'] = array(
+            'content'  => $pdfContent,
+            'fileName' => $fileName,
+        );
+
+        self::registerPdfAttach();
+    }
+
+    /**
+     * Register (once per request) the phpmailer_init handler that attaches the currently
+     * queued booking PDF. Reads from a global at send time so multiple emails in one
+     * request each attach their own PDF. wp_mail clears attachments per send.
+     */
+    private static function registerPdfAttach() {
+        if ( self::$pdfAttachRegistered ) {
+            return;
+        }
+
+        self::$pdfAttachRegistered = true;
+
+        add_action( 'phpmailer_init', function( $phpmailer ) {
+            $pdf = isset( $GLOBALS['seatreg_email_pdf_attachment'] ) ? $GLOBALS['seatreg_email_pdf_attachment'] : null;
+
+            if ( empty( $pdf['content'] ) ) {
+                return;
+            }
+
+            $phpmailer->AddStringAttachment( $pdf['content'], $pdf['fileName'], 'base64', 'application/pdf' );
+        } );
+    }
 }

--- a/php/services/SeatregTemplateService.php
+++ b/php/services/SeatregTemplateService.php
@@ -90,6 +90,11 @@ class SeatregTemplateService {
         return $template;
     }
 
+    public static function replaceBookingPDFAttachment($template) {
+        //The PDF is attached to the email in seatreg_send_approved_booking_email. Keyword itself renders nothing.
+        return str_replace(SEATREG_TEMPLATE_BOOKING_PDF_ATTACHMENT, '', $template);
+    }
+
     public static function approvedBookingTemplateProcessing($template, $bookingStatusLink, $bookings, $registrationCustomFields, $bookingId, $registration, $couponsEnabled, $appliedCoupon) {
         $template = self::sanitizeTemplate($template);
         $template = self::replaceLineBreaksWithBrTags($template);
@@ -99,7 +104,8 @@ class SeatregTemplateService {
         $template = self::replacePaymentTable($template, $bookingId, $couponsEnabled, $appliedCoupon);
         $template = self::replaceCustomApprovedEmailText($template, $bookings);
         $template = self::replaceBookingPDFLink($template, $bookingId);
-        
+        $template = self::replaceBookingPDFAttachment($template);
+
         $message = $template;
 
         return $message;

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,7 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 * Added the option to customize email colors (background, heading, and text) per registration.
 * Added the option to show logo at the top of emails, with a selectable alignment, per registration.
 * Seat labels are now shown in the cart, checkout, booking emails, the booking status page, and the PDF, XLSX and TXT exports.
+* Added the [booking-pdf-attachment] keyword for the approved booking receipt email template, which attaches the booking PDF to the email.
 
 = 1.71.0 =
 * Removed bookings are now kept in a new "Deleted" tab in the booking manager instead of being erased right away.


### PR DESCRIPTION
Adds a new `[booking-pdf-attachment]` keyword for the approved booking receipt email
template. When the keyword is present in the template, the booking PDF is generated and
attached to the email. The keyword itself renders as nothing in the email body.