### PR TITLE
Show each booking field on its own row in emails to prevent cut off content

### DIFF
--- a/php/emails.php
+++ b/php/emails.php
@@ -25,7 +25,7 @@ function seatreg_send_booking_notification_email($registrationCode, $bookingId, 
    
     /* translators: %s: Registration name */
     $message = esc_html__("Hello", 'seatreg') . "<br>" . sprintf(esc_html__("This is a notification email telling you that %s has a new booking", "seatreg"), $registrationName ) . "<br><br>" . esc_html__("You can disable booking notification in options if you don't want to receive them.", "seatreg") . "<br><br>";
-    $message .= SeatregBookingService::generateBookingTable($registrationCustomFields, $bookings, $registration);
+    $message .= SeatregBookingService::generateEmailBookingTable($registrationCustomFields, $bookings, $registration);
 
     /* translators: %s: Registration name */
     $emailSubject = sprintf(esc_html__("%s has a new booking", "seatreg"), $registrationName);
@@ -89,7 +89,7 @@ function seatreg_send_approved_booking_email($bookingId, $registrationCode, $tem
         $message .= esc_html__('Booking status link:', 'seatreg') . ' <a href="'. $bookingStatusUrl .'" target="_blank">'. esc_url($bookingStatusUrl) .'</a>';
         $message .= '</p>';
 
-        $bookingTable = SeatregBookingService::generateBookingTable($registrationCustomFields, $bookings, $registration);
+        $bookingTable = SeatregBookingService::generateEmailBookingTable($registrationCustomFields, $bookings, $registration);
         $message .= $bookingTable;
 
         if ( $couponsEnabled && $appliedCoupon ) {
@@ -98,7 +98,7 @@ function seatreg_send_approved_booking_email($bookingId, $registrationCode, $tem
 
         if( SeatregBookingService::getBookingTotalCost($bookingId, $registration->registration_layout) > 0 ) {
             $message .= '<br>';
-            $message .= SeatregBookingService::generatePaymentTable($bookingId, $couponsEnabled, $appliedCoupon);
+            $message .= SeatregBookingService::generateEmailPaymentTable($bookingId, $couponsEnabled, $appliedCoupon);
         }
     }
 

--- a/php/services/SeatregBookingService.php
+++ b/php/services/SeatregBookingService.php
@@ -5,6 +5,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class SeatregBookingService {
+    //Kept inline rather than in the email stylesheet because several email clients strip <style> blocks.
+    const EMAIL_TABLE_STYLE = 'width:100%;max-width:100%;border-collapse:collapse;table-layout:fixed;margin:0 0 12px 0;';
+    const EMAIL_TABLE_HEADER_STYLE = 'text-align:left;padding:6px 8px;border:1px solid #e2e8f0;background-color:#f1f4f9;font-weight:600;word-break:break-word;overflow-wrap:break-word;';
+    const EMAIL_TABLE_VALUE_STYLE = 'padding:6px 8px;border:1px solid #e2e8f0;word-break:break-word;overflow-wrap:break-word;';
+
     /**
      *
      * Return booking total cost
@@ -102,15 +107,14 @@ class SeatregBookingService {
 
     /**
      *
-     * Generate booking table
+     * Collect the columns and values shown for a booking
      * @param array $registrationCustomFields custom fields added to registration
      * @param array $bookings The UUID of the booking
      * @param object $registration Registration data
-     * @return string Booking table markup
-     * 
+     * @return array 'headers' => column labels, 'rows' => label/value pairs per booking. Values are unescaped
+     *
     */
-
-    public static function generateBookingTable($registrationCustomFields, $bookings, $registration) {
+    private static function getBookingTableData($registrationCustomFields, $bookings, $registration) {
         $enteredCustomFieldData = json_decode($bookings[0]->custom_field_data);
         $customFieldLabels = array_map(function($customField) {
             return $customField->label;
@@ -125,60 +129,94 @@ class SeatregBookingService {
         }
 
         $hasLegends = count(array_filter($seatLegends)) > 0;
-
-        $bookingTable = '<table style="border: 1px solid black;border-collapse: collapse;">
-            <tr>
-            <th style="border:1px solid black;text-align:left;padding: 6px;">' . __('Name', 'seatreg') . '</th>
-            <th style="border:1px solid black;text-align:left;padding: 6px;">' . $spotName . '</th>
-            <th style="border:1px solid black;text-align:left;padding: 6px;">' . __('Room', 'seatreg') . '</th>';
+        $headers = array( __('Name', 'seatreg'), $spotName, __('Room', 'seatreg') );
 
         if($hasLegends) {
-            $bookingTable .= '<th style="border:1px solid black;text-align:left;padding: 6px;">' . __('Label', 'seatreg') . '</th>';
+            $headers[] = __('Label', 'seatreg');
         }
 
-        $bookingTable .= '<th style="border:1px solid black;text-align:left;padding: 6px;">' . __('Email', 'seatreg') . '</th>';
+        $headers[] = __('Email', 'seatreg');
 
         if($hasCalendarDate) {
-            $bookingTable .= '<th style="border:1px solid black;text-align: left;padding: 6px;">' . __('Calendar date', 'seatreg') . '</th>';
+            $headers[] = __('Calendar date', 'seatreg');
         }
-        
+
         foreach($customFieldLabels as $customFieldLabel) {
-            $bookingTable .= '<th style="border:1px solid black;text-align: left;padding: 6px;">' . esc_html($customFieldLabel) . '</th>';
+            $headers[] = $customFieldLabel;
         }
-        $bookingTable .= '</tr>';
+
+        $rows = array();
 
         foreach ($bookings as $bookingKey => $booking) {
             $bookingCustomFields = json_decode($booking->custom_field_data);
-            $bookingTable .= '<tr>
-                <td style="border:1px solid black;padding: 6px;">'. esc_html($booking->first_name . ' ' .  $booking->last_name) .'</td>
-                <td style="border:1px solid black;padding: 6px;">'. esc_html($booking->seat_nr) . '</td>
-                <td style="border:1px solid black;padding: 6px;">'. esc_html($booking->room_name) . '</td>';
+            $row = array(
+                array( 'label' => __('Name', 'seatreg'), 'value' => $booking->first_name . ' ' . $booking->last_name ),
+                array( 'label' => $spotName, 'value' => $booking->seat_nr ),
+                array( 'label' => __('Room', 'seatreg'), 'value' => $booking->room_name ),
+            );
 
-                if($hasLegends) {
-                    $bookingTable .= '<td style="border:1px solid black;padding: 6px;">'. esc_html($seatLegends[$bookingKey]) . '</td>';
-                }
+            if($hasLegends) {
+                $row[] = array( 'label' => __('Label', 'seatreg'), 'value' => $seatLegends[$bookingKey] );
+            }
 
-                $bookingTable .= '<td style="border:1px solid black;padding: 6px;">'. esc_html($booking->email) . '</td>';
+            $row[] = array( 'label' => __('Email', 'seatreg'), 'value' => $booking->email );
 
-                if($hasCalendarDate) {
-                    $bookingTable .= '<td style="border:1px solid black;padding: 6px;">'. esc_html($booking->calendar_date) . '</td>';
-                }
-    
-                if( is_array($bookingCustomFields) ) {
-                    foreach($bookingCustomFields as $bookingCustomField) {
-                        $valueToDisplay = $bookingCustomField->value;
-    
-                        $customFieldObject = array_values(array_filter($registrationCustomFields, function($custField) use($bookingCustomField) {
-                            return $custField->label === $bookingCustomField->label;
-                        }));
-        
-                        if( count($customFieldObject) > 0 && $customFieldObject[0]->type === 'check' ) {
-                            $valueToDisplay = $bookingCustomField->value === '1' ? esc_html__('Yes', 'seatreg') : esc_html__('No', 'seatreg');
-                        }
-                        $bookingTable .= '<td style="border:1px solid black;padding: 6px;">'. esc_html($valueToDisplay) . '</td>';
+            if($hasCalendarDate) {
+                $row[] = array( 'label' => __('Calendar date', 'seatreg'), 'value' => $booking->calendar_date );
+            }
+
+            if( is_array($bookingCustomFields) ) {
+                foreach($bookingCustomFields as $bookingCustomField) {
+                    $valueToDisplay = $bookingCustomField->value;
+
+                    $customFieldObject = array_values(array_filter($registrationCustomFields, function($custField) use($bookingCustomField) {
+                        return $custField->label === $bookingCustomField->label;
+                    }));
+
+                    if( count($customFieldObject) > 0 && $customFieldObject[0]->type === 'check' ) {
+                        $valueToDisplay = $bookingCustomField->value === '1' ? __('Yes', 'seatreg') : __('No', 'seatreg');
                     }
+
+                    $row[] = array( 'label' => $bookingCustomField->label, 'value' => $valueToDisplay );
                 }
-            
+            }
+
+            $rows[] = $row;
+        }
+
+        return array(
+            'headers' => $headers,
+            'rows' => $rows,
+        );
+    }
+
+    /**
+     *
+     * Generate booking table
+     * @param array $registrationCustomFields custom fields added to registration
+     * @param array $bookings The UUID of the booking
+     * @param object $registration Registration data
+     * @return string Booking table markup
+     *
+    */
+
+    public static function generateBookingTable($registrationCustomFields, $bookings, $registration) {
+        $tableData = self::getBookingTableData($registrationCustomFields, $bookings, $registration);
+        $bookingTable = '<table style="border: 1px solid black;border-collapse: collapse;"><tr>';
+
+        foreach($tableData['headers'] as $header) {
+            $bookingTable .= '<th style="border:1px solid black;text-align:left;padding: 6px;">' . esc_html($header) . '</th>';
+        }
+
+        $bookingTable .= '</tr>';
+
+        foreach($tableData['rows'] as $row) {
+            $bookingTable .= '<tr>';
+
+            foreach($row as $field) {
+                $bookingTable .= '<td style="border:1px solid black;padding: 6px;">' . esc_html($field['value']) . '</td>';
+            }
+
             $bookingTable .= '</tr>';
         }
 
@@ -187,31 +225,117 @@ class SeatregBookingService {
         return $bookingTable;
     }
 
-    public static function generatePaymentTable($bookingId, $couponsEnabled = false, $appliedCoupon = null) {
+    /**
+     *
+     * Generate booking table for emails. One row per field, so it fits the fixed width email card
+     * no matter how many custom fields the registration has
+     * @param array $registrationCustomFields custom fields added to registration
+     * @param array $bookings The UUID of the booking
+     * @param object $registration Registration data
+     * @return string Booking table markup
+     *
+    */
+    public static function generateEmailBookingTable($registrationCustomFields, $bookings, $registration) {
+        $tableData = self::getBookingTableData($registrationCustomFields, $bookings, $registration);
+        $bookingTable = '<div style="margin: 12px 0;">';
+
+        foreach($tableData['rows'] as $row) {
+            $bookingTable .= '<table width="100%" border="0" cellpadding="0" cellspacing="0" style="' . self::EMAIL_TABLE_STYLE . '">';
+
+            foreach($row as $field) {
+                if( $field['value'] === null || $field['value'] === '' ) {
+                    continue;
+                }
+
+                $bookingTable .= '<tr>';
+                $bookingTable .= '<th style="width:38%;' . self::EMAIL_TABLE_HEADER_STYLE . '">' . esc_html($field['label']) . '</th>';
+                $bookingTable .= '<td style="' . self::EMAIL_TABLE_VALUE_STYLE . '">' . esc_html($field['value']) . '</td>';
+                $bookingTable .= '</tr>';
+            }
+
+            $bookingTable .= '</table>';
+        }
+
+        $bookingTable .= '</div>';
+
+        return $bookingTable;
+    }
+
+    /**
+     *
+     * Collect the seats, their prices and the total cost of a booking
+     * @param string $bookingId booking id
+     * @param bool $couponsEnabled whether coupons are enabled for the registration
+     * @param object $appliedCoupon coupon applied to the booking
+     * @return array 'spotName', 'rows' => seat/price pairs, 'total'. Values are unescaped
+     *
+    */
+    private static function getPaymentTableData($bookingId, $couponsEnabled = false, $appliedCoupon = null) {
         $bookingData = SeatregBookingRepository::getDataRelatedToBooking($bookingId);
         $bookings = self::getBookingsCost($bookingId, $bookingData->registration_layout);
         $totalCost = 0;
-        $spotName = $bookingData->using_seats ? __('Seat', 'seatreg') : __('Place', 'seatreg');
-        $paymentTable = '<table style="border: 1px solid black;border-collapse: collapse;">
-            <tr>
-                <th style=";border:1px solid black;text-align: left;padding: 6px;">' . $spotName . '</th>
-                <th style=";border:1px solid black;text-align: left;padding: 6px;">' . __('Price', 'seatreg') . '</th>
-            </tr>';
+        $rows = array();
 
         foreach($bookings as $booking) {
             $totalCost += $booking->price;
             $priceDescription = $booking->description ? "($booking->description)" : null;
 
+            $rows[] = array(
+                'seatNr' => $booking->seatNr,
+                'price' => $booking->price . ' ' . $bookingData->paypal_currency_code . ' ' . $priceDescription,
+            );
+        }
+
+        return array(
+            'spotName' => $bookingData->using_seats ? __('Seat', 'seatreg') : __('Place', 'seatreg'),
+            'rows' => $rows,
+            'total' => ( $couponsEnabled ? self::applyCouponDiscountToTotalCost($totalCost, $appliedCoupon) : $totalCost ) . ' ' . $bookingData->paypal_currency_code,
+        );
+    }
+
+    public static function generatePaymentTable($bookingId, $couponsEnabled = false, $appliedCoupon = null) {
+        $tableData = self::getPaymentTableData($bookingId, $couponsEnabled, $appliedCoupon);
+        $paymentTable = '<table style="border: 1px solid black;border-collapse: collapse;">
+            <tr>
+                <th style="border:1px solid black;text-align: left;padding: 6px;">' . esc_html($tableData['spotName']) . '</th>
+                <th style="border:1px solid black;text-align: left;padding: 6px;">' . esc_html__('Price', 'seatreg') . '</th>
+            </tr>';
+
+        foreach($tableData['rows'] as $row) {
             $paymentTable .= '<tr>';
-                $paymentTable .= '<td style=";border:1px solid black;padding: 6px;"">'. esc_html($booking->seatNr) .'</td>';
-                $paymentTable .= '<td style=";border:1px solid black;padding: 6px;"">'. esc_html($booking->price) . ' ' . $bookingData->paypal_currency_code . ' ' . $priceDescription  . '</td>';
+                $paymentTable .= '<td style="border:1px solid black;padding: 6px;">'. esc_html($row['seatNr']) .'</td>';
+                $paymentTable .= '<td style="border:1px solid black;padding: 6px;">'. esc_html($row['price']) . '</td>';
             $paymentTable .= '</tr>';
         }
-        $totalCost = $couponsEnabled ? self::applyCouponDiscountToTotalCost($totalCost, $appliedCoupon) : $totalCost;
 
         $paymentTable .= '<tr>';
-            $paymentTable .= '<td style=";border:1px solid black;padding: 6px;font-weight:700">'.  __('Total', 'seatreg') .'</td>';
-            $paymentTable .= '<td style=";border:1px solid black;padding: 6px;font-weight:700">'. $totalCost . ' ' . $bookingData->paypal_currency_code . '</td>';
+            $paymentTable .= '<td style="border:1px solid black;padding: 6px;font-weight:700">'.  esc_html__('Total', 'seatreg') .'</td>';
+            $paymentTable .= '<td style="border:1px solid black;padding: 6px;font-weight:700">'. esc_html($tableData['total']) . '</td>';
+        $paymentTable .= '</tr>';
+
+        $paymentTable .= '</table>';
+
+        return $paymentTable;
+    }
+
+    public static function generateEmailPaymentTable($bookingId, $couponsEnabled = false, $appliedCoupon = null) {
+        $tableData = self::getPaymentTableData($bookingId, $couponsEnabled, $appliedCoupon);
+        $paymentTable = '<table width="100%" border="0" cellpadding="0" cellspacing="0" style="' . self::EMAIL_TABLE_STYLE . '">
+            <tr>
+                <th style="' . self::EMAIL_TABLE_HEADER_STYLE . '">' . esc_html($tableData['spotName']) . '</th>
+                <th style="' . self::EMAIL_TABLE_HEADER_STYLE . '">' . esc_html__('Price', 'seatreg') . '</th>
+            </tr>';
+
+        foreach($tableData['rows'] as $row) {
+            $paymentTable .= '<tr>';
+                $paymentTable .= '<td style="' . self::EMAIL_TABLE_VALUE_STYLE . '">'. esc_html($row['seatNr']) .'</td>';
+                $paymentTable .= '<td style="' . self::EMAIL_TABLE_VALUE_STYLE . '">'. esc_html($row['price']) . '</td>';
+            $paymentTable .= '</tr>';
+        }
+
+        $paymentTable .= '<tr>';
+            $paymentTable .= '<td style="' . self::EMAIL_TABLE_VALUE_STYLE . 'font-weight:700;">'.  esc_html__('Total', 'seatreg') .'</td>';
+            $paymentTable .= '<td style="' . self::EMAIL_TABLE_VALUE_STYLE . 'font-weight:700;">'. esc_html($tableData['total']) . '</td>';
         $paymentTable .= '</tr>';
 
         $paymentTable .= '</table>';

--- a/php/services/SeatregBookingService.php
+++ b/php/services/SeatregBookingService.php
@@ -214,7 +214,7 @@ class SeatregBookingService {
             $bookingTable .= '<tr>';
 
             foreach($row as $field) {
-                $bookingTable .= '<td style="border:1px solid black;padding: 6px;">' . esc_html($field['value']) . '</td>';
+                $bookingTable .= '<td style="border:1px solid black;padding: 6px;">' . esc_html($field['value'] ?? '') . '</td>';
             }
 
             $bookingTable .= '</tr>';
@@ -243,13 +243,9 @@ class SeatregBookingService {
             $bookingTable .= '<table width="100%" border="0" cellpadding="0" cellspacing="0" style="' . self::EMAIL_TABLE_STYLE . '">';
 
             foreach($row as $field) {
-                if( $field['value'] === null || $field['value'] === '' ) {
-                    continue;
-                }
-
                 $bookingTable .= '<tr>';
                 $bookingTable .= '<th style="width:38%;' . self::EMAIL_TABLE_HEADER_STYLE . '">' . esc_html($field['label']) . '</th>';
-                $bookingTable .= '<td style="' . self::EMAIL_TABLE_VALUE_STYLE . '">' . esc_html($field['value']) . '</td>';
+                $bookingTable .= '<td style="' . self::EMAIL_TABLE_VALUE_STYLE . '">' . esc_html($field['value'] ?? '') . '</td>';
                 $bookingTable .= '</tr>';
             }
 

--- a/php/services/SeatregTemplateService.php
+++ b/php/services/SeatregTemplateService.php
@@ -35,7 +35,7 @@ class SeatregTemplateService {
 
     public static function replaceBookingTable($template, $bookings, $registrationCustomFields, $registration) {
         if(self::doesTemplateKeywordExist($template, SEATREG_TEMPLATE_BOOKING_TABLE)) {
-            $bookingTable = SeatregBookingService::generateBookingTable($registrationCustomFields, $bookings, $registration);
+            $bookingTable = SeatregBookingService::generateEmailBookingTable($registrationCustomFields, $bookings, $registration);
 
             return str_replace(SEATREG_TEMPLATE_BOOKING_TABLE, $bookingTable, $template);
         }
@@ -65,7 +65,7 @@ class SeatregTemplateService {
 
     public static function replacePaymentTable($template, $bookingId, $couponsEnabled, $appliedCoupon) {
         if(self::doesTemplateKeywordExist($template, SEATREG_TEMPLATE_PAYMENT_TABLE)) {
-            $paymentTable = SeatregBookingService::generatePaymentTable($bookingId, $couponsEnabled, $appliedCoupon);
+            $paymentTable = SeatregBookingService::generateEmailPaymentTable($bookingId, $couponsEnabled, $appliedCoupon);
 
             return str_replace(SEATREG_TEMPLATE_PAYMENT_TABLE, $paymentTable, $template);
         }

--- a/php/templates/email/base.html
+++ b/php/templates/email/base.html
@@ -72,6 +72,9 @@
   </style>
   <style type="text/css">
     .seatreg-content table {
+      width: 100% !important;
+      max-width: 100% !important;
+      table-layout: fixed;
       border-collapse: collapse;
       margin: 12px 0;
       font-size: 14px;
@@ -83,12 +86,16 @@
       text-align: left;
       padding: 8px 10px;
       border: 1px solid #e2e8f0;
+      word-break: break-word;
+      overflow-wrap: break-word;
     }
 
     .seatreg-content td {
       padding: 8px 10px;
       border: 1px solid #e2e8f0;
       color: {{emailTextColor}};
+      word-break: break-word;
+      overflow-wrap: break-word;
     }
 
     .seatreg-content a {

--- a/php/templates/email/mjml/base.mjml
+++ b/php/templates/email/mjml/base.mjml
@@ -8,9 +8,9 @@
       <mj-section padding="0px" />
     </mj-attributes>
     <mj-style>
-      .seatreg-content table { border-collapse: collapse; margin: 12px 0; font-size: 14px; }
-      .seatreg-content th { background: #f1f4f9; color: {{emailTextColor}}; text-align: left; padding: 8px 10px; border: 1px solid #e2e8f0; }
-      .seatreg-content td { padding: 8px 10px; border: 1px solid #e2e8f0; color: {{emailTextColor}}; }
+      .seatreg-content table { width: 100% !important; max-width: 100% !important; table-layout: fixed; border-collapse: collapse; margin: 12px 0; font-size: 14px; }
+      .seatreg-content th { background: #f1f4f9; color: {{emailTextColor}}; text-align: left; padding: 8px 10px; border: 1px solid #e2e8f0; word-break: break-word; overflow-wrap: break-word; }
+      .seatreg-content td { padding: 8px 10px; border: 1px solid #e2e8f0; color: {{emailTextColor}}; word-break: break-word; overflow-wrap: break-word; }
       .seatreg-content a { color: #2b6cb0; }
       .seatreg-content p { margin: 0 0 14px 0; }
       .seatreg-content img { max-width: 100%; }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: reservation, online booking, event management, online registration, seat p
 Requires at least: 5.3
 Requires PHP: 7.2.28
 Tested up to: 7.0
-Stable tag: 1.72.0
+Stable tag: 1.72.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -48,6 +48,9 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 7. Seat custom numbering
 
 == Changelog ==
+
+= 1.72.1 =
+* Booking and payment tables in emails now list each field on its own row, preventing wide tables from cutting off email content on the right.
 
 = 1.72.0 =
 * Emails sent to bookers now have a cleaner design.

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,7 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 
 = 1.72.1 =
 * Booking and payment tables in emails now list each field on its own row, preventing wide tables from cutting off email content on the right.
+* The Home page now shows a notice when a new plugin version is available.
 
 = 1.72.0 =
 * Emails sent to bookers now have a cleaner design.

--- a/seatreg.php
+++ b/seatreg.php
@@ -6,7 +6,7 @@
 	Author: Siim Kirjanen
 	Author URI: https://github.com/SiimKirjanen
 	Text Domain: seatreg
-	Version: 1.72.0
+	Version: 1.72.1
 	Requires at least: 5.3
 	Requires PHP: 7.2.28
 	License: GPLv2 or later


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/new-booking-notification/

The 600px email card added in 1.72.0 has `overflow:hidden`, and the booking table
had no width constraint — with enough custom fields it grew wider than the card
and everything past 600px got clipped, heading and body text included.

Booking and payment tables in emails now render each field on its own row, so they
always fit. The booking status page keeps the existing grid.