### PR TITLE
Set booking approval date when a payment approves the booking

### DIFF
--- a/php/payment/SeatregPaymentBase.php
+++ b/php/payment/SeatregPaymentBase.php
@@ -36,6 +36,10 @@ class SeatregPaymentBase {
 		SeatregBookingService::changeBookingStatus($status, $this->_bookingId);
 	}
 
+    protected function approveBooking() {
+		SeatregBookingService::setBookingApproved($this->_bookingId);
+	}
+
     protected function changePaymentStatus($status = SEATREG_PAYMENT_COMPLETED) {
 		SeatregPaymentService::changePaymentStatus($status, $this->_bookingId);
 	}
@@ -48,7 +52,7 @@ class SeatregPaymentBase {
 		if($this->_setBookingConfirmed === '1') {
 			$bookingData = SeatregBookingRepository::getDataRelatedToBooking($this->_bookingId);
 
-			$this->changeBookingStatus(SEATREG_BOOKING_APPROVED);
+			$this->approveBooking();
 			seatreg_add_activity_log('booking', $this->_bookingId, "Booking set to approved state by the system ($this->_paymentMethod)", false);
 			seatreg_send_approved_booking_email($this->_bookingId, $this->_registrationCode, $bookingData->approved_booking_email_template);
 			SeatregActionsService::triggerBookingApprovedAction($this->_bookingId);

--- a/php/services/SeatregBookingService.php
+++ b/php/services/SeatregBookingService.php
@@ -107,6 +107,30 @@ class SeatregBookingService {
 
     /**
      *
+     * Set booking approved and record the approval date
+     * @param string $bookingId The UUID of the booking
+     * @return (int|false) The number of rows updated, or false on error.
+     *
+    */
+    public static function setBookingApproved($bookingId) {
+        global $seatreg_db_table_names;
+		global $wpdb;
+
+        return $wpdb->update(
+			$seatreg_db_table_names->table_seatreg_bookings,
+			array(
+				'status' => SEATREG_BOOKING_APPROVED,
+				'booking_confirm_date' => time()
+			),
+			array(
+				'booking_id' => $bookingId
+			),
+			'%s'
+		);
+    }
+
+    /**
+     *
      * Collect the columns and values shown for a booking
      * @param array $registrationCustomFields custom fields added to registration
      * @param array $bookings The UUID of the booking

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,7 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 = 1.73.0 =
 * Added a new PayPal payment integration that uses the PayPal API and webhooks. It is configured with a client id and secret from the PayPal developer dashboard.
 * The old PayPal payment integration still works, but PayPal now considers it legacy, so it is marked as legacy in the settings. Moving to the new one is recommended.
+* The booking approval date is now recorded when a completed payment approves the booking.
 
 = 1.72.1 =
 * Booking and payment tables in emails now list each field on its own row, preventing wide tables from cutting off email content on the right.


### PR DESCRIPTION
A completed payment approved the booking but did not record the approval date. It is now recorded for all three payment methods.
