### PR TITLE
Keep the selected seat animation after a room change

### DIFF
--- a/php/enqueue_public.php
+++ b/php/enqueue_public.php
@@ -73,7 +73,7 @@ function seatreg_public_scripts_and_styles() {
 		wp_enqueue_script('jquery-powertip', SEATREG_PLUGIN_FOLDER_URL . 'js/jquery.powertip.js' , array(), '1.2.0', true);
 		wp_enqueue_script('pg-calendar', SEATREG_PLUGIN_FOLDER_URL . 'js/pg-calendar/dist/js/pignose.calendar.full.min.js' , array('jquery'), '1.4.31', false);
 		wp_enqueue_script('seatreg-utils', SEATREG_PLUGIN_FOLDER_URL . 'js/utils.js' , array(), '1.2.0', true);
-		wp_enqueue_script('seatreg-registration', SEATREG_PLUGIN_FOLDER_URL . 'registration/js/registration.js' , array('jquery', 'date-format', 'iscroll-zoom', 'jquery-powertip', 'seatreg-utils'), '1.35.0', true);
+		wp_enqueue_script('seatreg-registration', SEATREG_PLUGIN_FOLDER_URL . 'registration/js/registration.js' , array('jquery', 'date-format', 'iscroll-zoom', 'jquery-powertip', 'seatreg-utils'), '1.36.0', true);
 		wp_enqueue_script('alertify', SEATREG_PLUGIN_FOLDER_URL . 'js/alertify.js', array('jquery'), '1.0.0', true);
 
 		$data = seatreg_get_options_reg($_GET['c']);

--- a/registration/js/registration.js
+++ b/registration/js/registration.js
@@ -520,7 +520,8 @@
 
 				if(selectedElement) {
 					selectedElement.setAttribute('data-selectedbox','true');
-					selectedElement.classList.add('selected-box'); 
+					selectedElement.classList.add('selected-box');
+					selectedElement.style.setProperty('--animationColor', selectedElement.style.backgroundColor);
 				}
 			}
 		}


### PR DESCRIPTION
Selecting a seat, changing room and coming back left the seat looking
unselected. The seat map rebuild restored the selected marker but not the
inline --animationColor that the glow reads. It now restores the colour too.