### PR TITLE
Add shortcode room attribute to choose which room the registration opens on

### DIFF
--- a/php/enqueue_public.php
+++ b/php/enqueue_public.php
@@ -73,7 +73,7 @@ function seatreg_public_scripts_and_styles() {
 		wp_enqueue_script('jquery-powertip', SEATREG_PLUGIN_FOLDER_URL . 'js/jquery.powertip.js' , array(), '1.2.0', true);
 		wp_enqueue_script('pg-calendar', SEATREG_PLUGIN_FOLDER_URL . 'js/pg-calendar/dist/js/pignose.calendar.full.min.js' , array('jquery'), '1.4.31', false);
 		wp_enqueue_script('seatreg-utils', SEATREG_PLUGIN_FOLDER_URL . 'js/utils.js' , array(), '1.2.0', true);
-		wp_enqueue_script('seatreg-registration', SEATREG_PLUGIN_FOLDER_URL . 'registration/js/registration.js' , array('jquery', 'date-format', 'iscroll-zoom', 'jquery-powertip', 'seatreg-utils'), '1.36.0', true);
+		wp_enqueue_script('seatreg-registration', SEATREG_PLUGIN_FOLDER_URL . 'registration/js/registration.js' , array('jquery', 'date-format', 'iscroll-zoom', 'jquery-powertip', 'seatreg-utils'), '1.37.0', true);
 		wp_enqueue_script('alertify', SEATREG_PLUGIN_FOLDER_URL . 'js/alertify.js', array('jquery'), '1.0.0', true);
 
 		$data = seatreg_get_options_reg($_GET['c']);
@@ -86,6 +86,10 @@ function seatreg_public_scripts_and_styles() {
 		$registrationTimeRestrictions = json_encode( SeatregTimeRepository::getTimeInfoForRegistrationView($data->registration_start_time, $data->registration_end_time) );
 		$isLoggedIn = SeatregAuthService::isLoggedIn();
 		$couponsEnabled = SeatregCouponRepository::areCouponsEnabled($data->registration_code);
+		$initialRoomUuid = !empty($_GET['room']) ? SeatregLayoutService::findRoomUuidByName(
+			SeatregLayoutService::getRoomDataFromLayout($data->registration_layout),
+			sanitize_text_field( wp_unslash($_GET['room']) )
+		) : null;
 
 		$inlineScript = 'function showErrorView(title) {';
 			$inlineScript .= "jQuery('body').addClass('error-view').html('";
@@ -128,6 +132,7 @@ function seatreg_public_scripts_and_styles() {
 			$inlineScript .= 'var requireName = "' . esc_js($data->require_name ? '1' : '0') . '";';
 			$inlineScript .= 'var automaticBookingConfirmDialog = "' . esc_js($data->automatic_booking_confirm_dialog ? '1' : '0') . '";';
 			$inlineScript .= 'var seatregCouponsEnabled = "' . esc_js($couponsEnabled ? '1' : '0') . '";';
+			$inlineScript .= 'var seatregInitialRoomUuid = "' . esc_js($initialRoomUuid) . '";';
 			$inlineScript .= '} catch(err) {';
 				$inlineScript .= "showErrorView('Data initialization failed');";
 				$inlineScript .= "console.log(err);";

--- a/php/seatreg_functions.php
+++ b/php/seatreg_functions.php
@@ -491,7 +491,7 @@ function seatreg_generate_my_registrations_section() {
 				<?php
 					seatreg_more_items_modal( $registration->registration_code );
 					seatreg_copy_registration_modal( $registration->registration_code );
-					seatreg_shortcode_modal( $registration->registration_code );
+					seatreg_shortcode_modal( $registration->registration_code, SeatregLayoutService::getRoomDataFromLayout($registration->registration_layout) );
 				?>
 			</div>
 		<?php
@@ -2318,7 +2318,7 @@ function seatreg_copy_registration_modal($registrationCode) {
 	require( SEATREG_PLUGIN_FOLDER_DIR . 'php/views/modals/copy-registration-modal.php' );
 }
 
-function seatreg_shortcode_modal($registrationCode) {
+function seatreg_shortcode_modal($registrationCode, $rooms) {
 	require( SEATREG_PLUGIN_FOLDER_DIR . 'php/views/modals/shortcode-modal.php' );
 }
 

--- a/php/seatreg_shortcode.php
+++ b/php/seatreg_shortcode.php
@@ -8,6 +8,7 @@
             'height'        => '',
             'mobile_height' => '',
             'mobile_max_width'    => '720', // default mobile breakpoint
+            'room'          => '', // name of the room the registration opens on
         ), $atts, 'seatreg' );
 
         if ( empty($atts['code']) || empty($atts['height']) ) {
@@ -30,7 +31,25 @@
             return "Invalid breakpoint value";
         }
         
-        $seatregRegistrationUrl = esc_url(SeatregLinksService::getRegistrationURL() . "?seatreg=registration&c=". $atts['code']);
+        $roomQueryParam = '';
+
+        if ( !empty($atts['room']) ) {
+            $registration = SeatregRegistrationRepository::getRegistrationByCode( $atts['code'] );
+
+            if ( !$registration ) {
+                return "Registration not found";
+            }
+
+            $roomData = SeatregLayoutService::getRoomDataFromLayout( $registration->registration_layout );
+
+            if ( !SeatregLayoutService::findRoomUuidByName( $roomData, $atts['room'] ) ) {
+                return "Room not found";
+            }
+
+            $roomQueryParam = '&room=' . urlencode( $atts['room'] );
+        }
+
+        $seatregRegistrationUrl = esc_url(SeatregLinksService::getRegistrationURL() . "?seatreg=registration&c=". $atts['code'] . $roomQueryParam);
         $height = (int) esc_attr($atts['height']);
         $mobileHeight = (int) esc_attr($atts['mobile_height']);
         $breakpoint = (int) esc_attr($atts['mobile_max_width']);

--- a/php/services/SeatregLayoutService.php
+++ b/php/services/SeatregLayoutService.php
@@ -147,6 +147,24 @@ class SeatregLayoutService {
         return $roomUUID;
     }
 
+     /**
+     *
+     * Find room UUID by room name. Match ignores case and surrounding spaces, like the room name uniqueness check in the map builder
+     * @param array $roomData Rooms in the layout
+     * @param string $roomName Name of the room to look for
+     * @return string|null Room UUID. Null when no room has that name
+     *
+    */
+    public static function findRoomUuidByName($roomData, $roomName) {
+        foreach( $roomData as $layoutData ) {
+            if( strcasecmp( trim($layoutData->room->name), trim($roomName) ) === 0 ) {
+                return $layoutData->room->uuid;
+            }
+        }
+
+        return null;
+    }
+
     public static function getRoomsLength($roomData) {
         return count($roomData);
     }

--- a/php/views/modals/shortcode-modal.php
+++ b/php/views/modals/shortcode-modal.php
@@ -13,6 +13,22 @@
                 <code class="shortcode-example">[seatreg code=<?php echo esc_html($registrationCode); ?> height=600 mobile_height=500]</code>
                 <p class="shortcode-instructions"><?php esc_html_e("You can customize the screen width below which the mobile height is applied (default: 720px).", "seatreg"); ?></p>
                 <code class="shortcode-example">[seatreg code=<?php echo esc_html($registrationCode); ?> height=600 mobile_height=500 mobile_max_width=600]</code>
+                <?php if( count($rooms) ) : ?>
+                    <p class="shortcode-instructions"><?php esc_html_e("You can choose which room the registration opens on.", "seatreg"); ?></p>
+                    <code class="shortcode-example">[seatreg code=<?php echo esc_html($registrationCode); ?> height=600 room="<?php echo esc_html($rooms[0]->room->name); ?>"]</code>
+                    <p class="shortcode-instructions">
+                        <?php esc_html_e("Available rooms", "seatreg"); ?>:
+                        <?php
+                            $roomNames = array();
+
+                            foreach($rooms as $roomData) {
+                                $roomNames[] = $roomData->room->name;
+                            }
+
+                            echo esc_html( implode(', ', $roomNames) );
+                        ?>
+                    </p>
+                <?php endif; ?>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal"><?php esc_html_e('Close', 'seatreg'); ?></button>

--- a/readme.txt
+++ b/readme.txt
@@ -50,7 +50,7 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 == Changelog ==
 
 = 1.74.0 =
-* The shortcode now takes an optional room attribute that sets which room the registration opens on, so the same registration can be embedded several times on one page with a different room each time.
+* The shortcode now takes an optional room attribute that sets which room the registration opens on.
 
 = 1.73.0 =
 * Added a new PayPal payment integration that uses the PayPal API and webhooks. It is configured with a client id and secret from the PayPal developer dashboard.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: reservation, online booking, event management, online registration, seat p
 Requires at least: 5.3
 Requires PHP: 7.2.28
 Tested up to: 7.0
-Stable tag: 1.73.0
+Stable tag: 1.74.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -48,6 +48,9 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 7. Seat custom numbering
 
 == Changelog ==
+
+= 1.74.0 =
+* The shortcode now takes an optional room attribute that sets which room the registration opens on, so the same registration can be embedded several times on one page with a different room each time.
 
 = 1.73.0 =
 * Added a new PayPal payment integration that uses the PayPal API and webhooks. It is configured with a client id and secret from the PayPal developer dashboard.

--- a/registration/js/registration.js
+++ b/registration/js/registration.js
@@ -124,6 +124,7 @@
 		this.automaticBookingConfirmDialog = window.automaticBookingConfirmDialog === '1';
 		this.couponsEnabled = window.seatregCouponsEnabled === '1';
 		this.zoomControlsOnTop = window.zoomControlsOnTop === '1';
+		this.initialRoomUuid = window.seatregInitialRoomUuid || null;
 		this.appliedCoupon = null;
 	}
 
@@ -235,6 +236,11 @@
 			$('body').append('<div class="under-construction-notify"><span class="icon-construction6 index-icon"></span>'+ translator.translate('_regUnderConstruction') +'</div>');
 		}else {
 			this.fillLocationObj();
+
+			if( this.initialRoomUuid !== null && this.locationObj.hasOwnProperty(this.initialRoomUuid) ) {
+				//registration was opened with a room selected. Open that room instead of the first one
+				this.currentRoom = this.locationObj[this.initialRoomUuid];
+			}
 
 			if( this.usingCalendar && !this.isSelectedCalendarDateAvalidable() ) {
 				this.paintRegistrationMessage(translator.translate('closedPleaseChooseNewDate'));
@@ -642,7 +648,15 @@ SeatReg.prototype.paintRoomsNav = function() {
 		navItem.appendTo(documentFragment);
 	}
 	$('#room-nav-items').html(documentFragment);
-	$('#room-nav-items .room-nav-link').first().trigger('click');
+
+	var activeRoomUuid = this.rooms[this.currentRoom].room.uuid;
+	var $activeNavLink = $('#room-nav-items').find('.room-nav-link[data-open="' + activeRoomUuid + '"]');
+
+	if($activeNavLink.length) {
+		$activeNavLink.trigger('click');
+	}else {
+		$('#room-nav-items .room-nav-link').first().trigger('click');
+	}
 };
 
 SeatReg.prototype.paintRegistrationMessage = function(text) {

--- a/seatreg.php
+++ b/seatreg.php
@@ -6,7 +6,7 @@
 	Author: Siim Kirjanen
 	Author URI: https://github.com/SiimKirjanen
 	Text Domain: seatreg
-	Version: 1.73.0
+	Version: 1.74.0
 	Requires at least: 5.3
 	Requires PHP: 7.2.28
 	License: GPLv2 or later


### PR DESCRIPTION
The shortcode now takes an optional room attribute that sets which room the
registration opens on: [seatreg code=dc77b9b3e5 height=600 room="3 room"]

Also, the room navigation is painted from the current room rather than always the
first one, so a calendar date change no longer throws the visitor back to room 1.