### PR TITLE
Ask caching plugins to skip SeatReg pages

### DIFF
--- a/php/seatreg_no_cache.php
+++ b/php/seatreg_no_cache.php
@@ -1,0 +1,45 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+//every plugin owned front end URL is routed by the seatreg query parameter, see seatreg_filters.php
+function seatreg_is_dynamic_public_page() {
+	return isset( $_GET['seatreg'] );
+}
+
+//set while this file is included, because some caches decide whether to store the response before any hook we could use
+if ( seatreg_is_dynamic_public_page() ) {
+	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+		define( 'DONOTCACHEPAGE', true );
+	}
+	if ( ! defined( 'DONOTCACHEDB' ) ) {
+		define( 'DONOTCACHEDB', true );
+	}
+
+	/*
+	 * The registration data is printed as an inline script, see enqueue_public.php. Script optimisation
+	 * bundles it into a static file that keeps being served after the data has changed, so the seat map
+	 * shows outdated colours, availability and bookings.
+	 */
+	if ( ! defined( 'DONOTMINIFY' ) ) {
+		define( 'DONOTMINIFY', true );
+	}
+	if ( ! defined( 'DONOTROCKETOPTIMIZE' ) ) {
+		define( 'DONOTROCKETOPTIMIZE', true );
+	}
+
+	add_filter( 'wpo_minify_run_on_page', '__return_false' );
+	add_filter( 'autoptimize_filter_noptimize', '__return_true' );
+}
+
+//LiteSpeed caches query string URLs by default, so it is the one most likely to store these pages
+add_action( 'wp', 'seatreg_disable_litespeed_cache' );
+function seatreg_disable_litespeed_cache() {
+	if ( ! seatreg_is_dynamic_public_page() ) {
+		return;
+	}
+
+	do_action( 'litespeed_control_set_nocache', 'SeatReg dynamic page' );
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: reservation, online booking, event management, online registration, seat p
 Requires at least: 5.3
 Requires PHP: 7.2.28
 Tested up to: 7.0
-Stable tag: 1.74.0
+Stable tag: 1.74.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -48,6 +48,9 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 7. Seat custom numbering
 
 == Changelog ==
+
+= 1.74.1 =
+* SeatReg now asks caching plugins not to store the registration view and its other pages.
 
 = 1.74.0 =
 * The shortcode now takes an optional room attribute that sets which room the registration opens on.

--- a/seatreg.php
+++ b/seatreg.php
@@ -6,7 +6,7 @@
 	Author: Siim Kirjanen
 	Author URI: https://github.com/SiimKirjanen
 	Text Domain: seatreg
-	Version: 1.74.0
+	Version: 1.74.1
 	Requires at least: 5.3
 	Requires PHP: 7.2.28
 	License: GPLv2 or later
@@ -76,6 +76,8 @@ require( 'php/SeatregBooking.php' );
 require( 'php/SeatregSubmitBookings.php' );
 require( 'php/SeatregDataValidation.php' );
 require( 'php/util/registration_time_status.php' );
+
+require( 'php/seatreg_no_cache.php' );
 
 if( is_admin() ) {
 	require( 'php/enqueue_admin.php' );


### PR DESCRIPTION
`DONOTCACHEPAGE` and `DONOTCACHEDB` are now set on the plugin's public pages so caching plugins skip them.
Ask optimization plugins not to bundle the registration data