### PR TITLE
Apply the 1.75.0 schema upgrade that a version number clash skipped

### DIFF
--- a/php/constants.php
+++ b/php/constants.php
@@ -9,7 +9,7 @@ define('SEATREG_SETTINGS_PAGE', admin_url('/admin.php?page=seatreg-options'));
 define('SEATREG_PAGE_ID', 'seatreg');
 
 // DB
-define('SEATREG_DB_VERSION', '1.62');
+define('SEATREG_DB_VERSION', '1.63');
 
 // Validation
 define('SEATREG_MANAGER_ALLOWED_ORDER', array('id', 'date', 'name', 'room', 'nr', 'payment-status'));
@@ -68,7 +68,7 @@ define('SEATREG_STRIPE_ZERO_DECIMAL_CURRENCIES', array('BIF', 'CLP', 'DJF', 'GNF
 define('SEATREG_ENCRYPTED_VALUE_PREFIX', 'seatreg_enc_v1:');
 
 // Migrations
-define('SEATREG_TRIGGER_MIGRATIONS', '3');
+define('SEATREG_TRIGGER_MIGRATIONS', '4');
 
 // Status
 define('SEATREG_BOOKING_DEFAULT', 0);

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,7 @@ It is commonly used for events and conferences, theaters and cinemas, classes an
 
 = 1.76.0 =
 * The Home page now shows your registrations as cards, each with its status, dates, and booking counts.
+* Fixed setting up Stripe payments on sites that were updated from an earlier version.
 
 = 1.75.0 =
 * Your Stripe API key and webhook secret are now stored encrypted.


### PR DESCRIPTION
1.74.0 and 1.75.0 both shipped SEATREG_DB_VERSION '1.62', so on installs that ran 1.74.x first the schema upgrade never ran and stripe_webhook_url was never created. Saving the Stripe settings then failed to store the webhook signing secret, making Stripe setup impossible.

Bumping to 1.63 lets dbDelta add the missing column, and SEATREG_TRIGGER_MIGRATIONS goes to 4 to re-run the backfill migration that failed for the same reason. Reported at https://wordpress.org/support/topic/unable-to-setup-stripe/.